### PR TITLE
Fix #28: hover crash on group name (defensive Map normalization)

### DIFF
--- a/src/stores/guestStore.test.ts
+++ b/src/stores/guestStore.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the defensive Map-shape watcher in guestStore that fixes
+ * #28 — hovering a group name in All Reservations could crash if
+ * suggestedGroups landed as a plain object (stale localStorage from an
+ * older build, HMR weirdness, dev-tools edits). The watcher normalizes
+ * any non-Map write back into a Map<string, Set<string>> synchronously
+ * so consumers can keep calling .entries() / .size / .get() naively.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useGuestStore } from './guestStore'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+    key: () => null,
+    length: 0,
+  }
+})()
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+describe('guestStore.suggestedGroups normalization', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('keeps a real Map as a Map (no spurious re-wrap)', () => {
+    const store = useGuestStore()
+    const map = new Map([['Smith Family', new Set(['g1', 'g2'])]])
+    store.suggestedGroups = map
+    // Pinia wraps the value in a reactive proxy, so identity (`toBe`)
+    // won't match — but it must still BE a Map and preserve members.
+    expect(store.suggestedGroups instanceof Map).toBe(true)
+    expect(store.suggestedGroups.size).toBe(1)
+    expect(Array.from(store.suggestedGroups.get('Smith Family') ?? [])).toEqual(['g1', 'g2'])
+  })
+
+  it('converts a plain object with array values back into a Map<string, Set>', () => {
+    const store = useGuestStore()
+    // Simulate stale localStorage from an older build that persisted
+    // suggestedGroups as `{ groupName: ['guest1', 'guest2'] }`.
+    store.suggestedGroups = { 'Smith Family': ['g1', 'g2'] } as unknown as Map<string, Set<string>>
+
+    expect(store.suggestedGroups instanceof Map).toBe(true)
+    expect(store.suggestedGroups.size).toBe(1)
+    const members = store.suggestedGroups.get('Smith Family')
+    expect(members instanceof Set).toBe(true)
+    expect(Array.from(members ?? [])).toEqual(['g1', 'g2'])
+  })
+
+  it('converts a plain object with broken {} values into empty Sets (lossy but does not crash)', () => {
+    // Sets serialize through JSON as {} — round-trip persistence loses
+    // the members. We can't recover them, but we MUST not crash.
+    const store = useGuestStore()
+    store.suggestedGroups = { 'Smith Family': {} } as unknown as Map<string, Set<string>>
+
+    expect(store.suggestedGroups instanceof Map).toBe(true)
+    const members = store.suggestedGroups.get('Smith Family')
+    expect(members instanceof Set).toBe(true)
+    expect(members?.size).toBe(0)
+  })
+
+  it('lets consumers call .entries() without throwing after a non-Map write', () => {
+    // This is the exact failure mode in issue #28.
+    const store = useGuestStore()
+    store.suggestedGroups = { 'A': ['g1'], 'B': ['g2'] } as unknown as Map<string, Set<string>>
+
+    expect(() => {
+      const out: string[] = []
+      for (const [name] of store.suggestedGroups.entries()) out.push(name)
+      return out
+    }).not.toThrow()
+
+    // hasGroupSuggestions / groupSuggestionCount also rely on .size
+    expect(store.hasGroupSuggestions).toBe(true)
+    expect(store.groupSuggestionCount).toBe(2)
+  })
+})

--- a/src/stores/guestStore.ts
+++ b/src/stores/guestStore.ts
@@ -4,7 +4,7 @@
  */
 
 import { defineStore } from 'pinia'
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import type { Guest, GuestInput } from '@/types'
 import { NON_ASSIGNABLE_HOUSING_TYPES } from '@/types/Constants'
 import { useSortConfig } from '@/shared/composables/useSortConfig'
@@ -18,8 +18,44 @@ export const useGuestStore = defineStore(
     const searchQuery = ref('')
     const savedScrollTop = ref(0)
 
-    // Ephemeral suggestion state (not persisted)
+    // Ephemeral suggestion state (not persisted under current `paths`,
+    // but historically was — stale localStorage from old builds can still
+    // deliver a plain Object on hydration, so consumers normalize defensively.
     const suggestedGroups = ref<Map<string, Set<string>>>(new Map())
+
+    // Defensive: hover/render paths reach `suggestedGroups.value` and call
+    // `.entries()`, `.size`, etc. If anything ever delivers a non-Map (HMR,
+    // legacy persisted shape, dev-tools edit), normalize to a Map so consumers
+    // don't TypeError. Sets serialized through JSON come back as `{}`, so
+    // values are accepted as Set | Array | (lossy) Object.
+    function asGroupMap(val: unknown): Map<string, Set<string>> {
+      if (val instanceof Map) return val as Map<string, Set<string>>
+      const out = new Map<string, Set<string>>()
+      if (val && typeof val === 'object') {
+        for (const [k, v] of Object.entries(val as Record<string, unknown>)) {
+          if (v instanceof Set) {
+            out.set(k, v as Set<string>)
+          } else if (Array.isArray(v)) {
+            out.set(k, new Set(v as string[]))
+          } else {
+            out.set(k, new Set())
+          }
+        }
+      }
+      return out
+    }
+
+    // Auto-correct any non-Map write back to a Map so downstream consumers
+    // never TypeError on `.entries()` / `.size` / `.get()` (issue #28).
+    watch(
+      suggestedGroups,
+      (val) => {
+        if (!(val instanceof Map)) {
+          suggestedGroups.value = asGroupMap(val)
+        }
+      },
+      { immediate: true, flush: 'sync' }
+    )
 
     // Getters
     const getGuestById = computed(() => {


### PR DESCRIPTION
## Summary

Fixes #28. Hovering a group name in **All Reservations** could crash with:

```
TypeError: u.value.entries is not a function or its return value is not iterable
```

Root cause: \`guestStore.suggestedGroups\` is typed as \`Map<string, Set<string>>\` but several call sites can land on a plain object instead — most likely from stale localStorage written by an older build that included \`suggestedGroups\` in its persist \`paths\`. HMR can produce the same shape during dev.

## Fix

Add a sync, immediate watcher inside the store that auto-corrects any non-Map write back to a Map via a new \`asGroupMap()\` helper:

- Map → pass through
- plain object with array values → \`new Map(Object.entries → new Set(arr))\`
- plain object with broken \`{}\` values (Sets that round-tripped through JSON) → empty Sets (lossy, but doesn't crash)

This means every other consumer (\`.entries()\`, \`.size\`, \`.get()\`, \`.forEach()\`) keeps working without any per-call defensive code.

## Test plan

- [ ] Manually reproduce: open the app with a stale localStorage entry that has \`suggestedGroups: {...}\`, hover over a group name in All Reservations → no console error.
- [ ] Fresh install: suggestGroupsByEmail still produces hover-able pills.
- [ ] Accept / reject / accept-all suggestions still work.
- [ ] No regression in GroupLinesOverlay (it has its own normalization at the prop boundary; both are now belt-and-suspenders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)