### PR TITLE
Fix: import-summary modal counts rows, not warning entries

### DIFF
--- a/src/features/csv/components/CSVWarningModal.vue
+++ b/src/features/csv/components/CSVWarningModal.vue
@@ -15,7 +15,12 @@
         <div v-if="warnings.length > 0" class="warnings-section">
           <div class="warnings-header">
             <span class="warning-icon">⚠</span>
-            {{ warnings.length }} row{{ warnings.length !== 1 ? 's were' : ' was' }} skipped:
+            <template v-if="skippedCount > 0">
+              {{ skippedCount }} row{{ skippedCount !== 1 ? 's' : '' }} skipped:
+            </template>
+            <template v-else>
+              {{ warnings.length }} note{{ warnings.length !== 1 ? 's' : '' }}:
+            </template>
           </div>
           <ul class="warnings-list">
             <li v-for="(warning, index) in warnings" :key="index" class="warning-item">
@@ -38,6 +43,12 @@ interface Props {
   successCount: number
   totalRows: number
   warnings: string[]
+  // Total rows dropped during import (non-active reservations + parse
+  // errors). Headline uses this so a single summary entry like "Skipped
+  // 4 non-active reservations" doesn't get reported as "1 row was
+  // skipped" (warnings.length counts entries, not rows). Defaults to 0
+  // → headline falls back to "X notes" when only entry-level info exists.
+  skippedCount?: number
 }
 
 withDefaults(defineProps<Props>(), {
@@ -45,6 +56,7 @@ withDefaults(defineProps<Props>(), {
   successCount: 0,
   totalRows: 0,
   warnings: () => [],
+  skippedCount: 0,
 })
 
 const emit = defineEmits<{

--- a/src/features/csv/components/GuestCSVUpload.vue
+++ b/src/features/csv/components/GuestCSVUpload.vue
@@ -29,6 +29,7 @@
       :success-count="successCount"
       :total-rows="totalRows"
       :warnings="warnings"
+      :skipped-count="skippedCount"
       @close="closeWarningModal"
     />
 
@@ -91,6 +92,10 @@ const showWarningModal = ref(false)
 const successCount = ref(0)
 const totalRows = ref(0)
 const warnings = ref<string[]>([])
+// Actual row count dropped (non-active + parse errors) — distinct from
+// warnings.length, which counts entries (one summary entry can cover
+// many rows). Used by the modal headline.
+const skippedCount = ref(0)
 
 // Stash for the parsed CSV between parse and the merge handler.
 const pendingCSVData = ref<{ guests: Guest[]; warnings: string[]; totalRows: number } | null>(null)
@@ -100,6 +105,7 @@ function closeWarningModal() {
   successCount.value = 0
   totalRows.value = 0
   warnings.value = []
+  skippedCount.value = 0
 }
 
 async function handleFileChange(event: Event) {
@@ -172,6 +178,8 @@ function performImport(result: { guests: Guest[]; warnings: string[]; totalRows:
     successCount.value = activeGuests.length
     totalRows.value = result.totalRows
     warnings.value = allWarnings
+    // Actual rows dropped: non-active reservations + per-row parse errors.
+    skippedCount.value = skipped + result.warnings.length
     showWarningModal.value = true
   }
 }
@@ -303,6 +311,10 @@ function handleAddAndUpdate() {
     successCount.value = newRows.length
     totalRows.value = pendingCSVData.value.totalRows
     warnings.value = pendingCSVData.value.warnings
+    // Re-import path only surfaces parse errors here (non-active rows
+    // are reflected in the diff modal instead), so each warning entry
+    // == one row.
+    skippedCount.value = pendingCSVData.value.warnings.length
     showWarningModal.value = true
   }
 


### PR DESCRIPTION
## Summary

Smoke-test surfaced a UX bug in the CSV import-summary modal: the headline counted \`warnings.length\` (the number of *entries* in the warnings array) and labeled it as "rows skipped." That was true when each entry was a per-row parse error, but **false** for the new "Skipped N non-active reservations" summary entry, which is one entry that represents N rows.

Concretely: a CSV with 4 cancelled rows showed:

> ⚠ **1 row was skipped:**
>    Skipped 4 non-active reservations (cancelled or incomplete).

…where "1" and "4" disagree. Operator does a double-take.

## Fix

- \`CSVWarningModal\` now takes an optional \`skippedCount\` prop. When > 0, the headline uses it instead of \`warnings.length\`. When 0 (no caller passes it), it gracefully falls back to "X notes:" instead of lying about row counts.
- \`GuestCSVUpload\` passes the actual dropped-row count:
  - \`performImport\`: \`skipped + result.warnings.length\` (non-active drops + per-row parse errors)
  - \`handleAddAndUpdate\`: \`pendingCSVData.value.warnings.length\` (parse errors only — non-active rows are reflected in the diff modal)

## Verified

Smoke-tested with the same CSV that surfaced the bug. Headline now reads **"4 rows skipped:"** matching the body summary "Skipped 4 non-active reservations (cancelled or incomplete)."

## Test plan

- [ ] Upload a CSV with 4 cancelled rows → headline says "4 rows skipped" (not "1 row was skipped")
- [ ] Upload a CSV with 2 cancelled + 1 malformed row → headline says "3 rows skipped" with 2 entries (one summary + one row-specific)
- [ ] Upload a clean CSV with no warnings → no warnings section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)