### PR TITLE
Polish notes icon contrast + drop year from bed-slot dates

### DIFF
--- a/src/features/dormitories/components/BedSlot.vue
+++ b/src/features/dormitories/components/BedSlot.vue
@@ -46,9 +46,9 @@
             </span>
           </span>
           <span v-if="assignedGuest.arrival || assignedGuest.departure" class="date-info">
-            <span v-if="assignedGuest.arrival">{{ formatGuestDate(assignedGuest.arrival) }}</span>
+            <span v-if="assignedGuest.arrival">{{ formatGuestDateShort(assignedGuest.arrival) }}</span>
             <span v-if="assignedGuest.arrival && assignedGuest.departure">→</span>
-            <span v-if="assignedGuest.departure">{{ formatGuestDate(assignedGuest.departure) }}</span>
+            <span v-if="assignedGuest.departure">{{ formatGuestDateShort(assignedGuest.departure) }}</span>
           </span>
         </div>
         <ValidationWarning v-if="warnings.length > 0" :warnings="warnings" />
@@ -67,9 +67,9 @@
             </span>
           </span>
           <span v-if="suggestedGuest.arrival || suggestedGuest.departure" class="date-info">
-            <span v-if="suggestedGuest.arrival">{{ formatGuestDate(suggestedGuest.arrival) }}</span>
+            <span v-if="suggestedGuest.arrival">{{ formatGuestDateShort(suggestedGuest.arrival) }}</span>
             <span v-if="suggestedGuest.arrival && suggestedGuest.departure">→</span>
-            <span v-if="suggestedGuest.departure">{{ formatGuestDate(suggestedGuest.departure) }}</span>
+            <span v-if="suggestedGuest.departure">{{ formatGuestDateShort(suggestedGuest.departure) }}</span>
           </span>
           <span class="suggestion-badge">Suggested</span>
         </div>
@@ -146,7 +146,7 @@ import { useDragDrop } from '@/features/assignments/composables/useDragDrop'
 import { useGroupLinking } from '@/features/guests/composables/useGroupLinking'
 import { useUtils } from '@/shared/composables/useUtils'
 import { useDropValidation } from '@/shared/composables/useDropValidation'
-import { parseLocalDate, formatGuestDate } from '@/shared/composables/useUtils'
+import { parseLocalDate, formatGuestDate, formatGuestDateShort } from '@/shared/composables/useUtils'
 import { useOverlapConfirm } from '@/shared/composables/useOverlapConfirm'
 import { ValidationWarning } from '@/shared/components'
 import GuestFormModal from '@/features/guests/components/GuestFormModal.vue'
@@ -756,11 +756,17 @@ const dropzoneProps = useDroppableBed(props.bed.bedId, handleDrop)
     background: #f3f4f6;
   }
 
+  /* Notes icon when the guest actually has notes — full opacity so it
+     reads as a clear, active affordance against the faded empty state. */
+  &.has-notes {
+    opacity: 1;
+  }
+
   /* When the notes icon is leading the row but the guest has no notes,
      keep it visible (per operator request — always-visible icons) but
      very faded and non-interactive. */
   &.no-notes-empty {
-    opacity: 0.18;
+    opacity: 0.08;
     cursor: default;
     pointer-events: none;
   }
@@ -776,8 +782,8 @@ const dropzoneProps = useDroppableBed(props.bed.bedId, handleDrop)
       position: absolute;
       top: 0;
       right: 0;
-      width: 6px;
-      height: 6px;
+      width: 9px;
+      height: 9px;
       background: #5b21b6;
       border-radius: 50%;
       border: 1px solid white;

--- a/src/features/guests/components/GuestRow.vue
+++ b/src/features/guests/components/GuestRow.vue
@@ -868,7 +868,7 @@ tr.guest-row {
      in the row so the column width stays consistent, but visually
      distinct from rows that do have notes. */
   &.no-notes-empty {
-    opacity: 0.18;
+    opacity: 0.08;
     cursor: default;
     pointer-events: none;
   }
@@ -879,8 +879,8 @@ tr.guest-row {
     position: absolute;
     top: 0;
     right: 0;
-    width: 6px;
-    height: 6px;
+    width: 9px;
+    height: 9px;
     background: #5b21b6;
     border-radius: 50%;
     border: 1px solid white;

--- a/src/shared/composables/useUtils.test.ts
+++ b/src/shared/composables/useUtils.test.ts
@@ -10,6 +10,7 @@ import {
   parseLocalDate,
   stayCoversDate,
   formatGuestDate,
+  formatGuestDateShort,
 } from './useUtils'
 
 describe('parseLocalDate', () => {
@@ -163,5 +164,30 @@ describe('formatGuestDate', () => {
 
   it('returns input unchanged when it cannot be parsed', () => {
     expect(formatGuestDate('not a date')).toBe('not a date')
+  })
+})
+
+describe('formatGuestDateShort', () => {
+  it('drops the year from ISO input', () => {
+    expect(formatGuestDateShort('2026-05-30')).toBe('May 30')
+    expect(formatGuestDateShort('2026-06-01')).toBe('June 1')
+  })
+
+  it('drops the year from already-canonical input', () => {
+    expect(formatGuestDateShort('May 30, 2026')).toBe('May 30')
+  })
+
+  it('drops the year from Planyo-style "30-May-25"', () => {
+    expect(formatGuestDateShort('30-May-25')).toBe('May 30')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(formatGuestDateShort('')).toBe('')
+    expect(formatGuestDateShort(null)).toBe('')
+    expect(formatGuestDateShort(undefined)).toBe('')
+  })
+
+  it('returns unparseable input unchanged (no year suffix to strip)', () => {
+    expect(formatGuestDateShort('not a date')).toBe('not a date')
   })
 })

--- a/src/shared/composables/useUtils.ts
+++ b/src/shared/composables/useUtils.ts
@@ -120,6 +120,16 @@ export function formatGuestDate(value: string | null | undefined): string {
 }
 
 /**
+ * Like {@link formatGuestDate} but without the year — for compact
+ * contexts (bed-slot date ranges) where the retreat year is obvious
+ * from context. "May 30, 2026" → "May 30". Inputs without a trailing
+ * year are returned as formatted by formatGuestDate.
+ */
+export function formatGuestDateShort(value: string | null | undefined): string {
+  return formatGuestDate(value).replace(/,\s*\d{4}$/, '')
+}
+
+/**
  * Returns true if the View Date falls within a stay (inclusive of arrival,
  * exclusive of departure). Used to pick which assignment to display in a
  * bed when the operator has a date filter active.


### PR DESCRIPTION
## Summary

Two operator-requested visual tweaks to the room-assignment rows (Table View / BedSlot):

### 1. Notes icon — wider faded/active contrast
- Empty-state icon (\`no-notes-empty\`): opacity **0.18 → 0.08** — now barely-there.
- Has-notes icon: pinned to **full opacity** in BedSlot (GuestRow base was already 1.0).
- Net: "has notes" reads as a clear affordance; "no notes" recedes into the background.

### 2. Internal-notes purple dot — 50% larger
- The \`has-internal\` badge dot: **6px → 9px** in both BedSlot and GuestRow. Noticeable at a glance now.

### 3. Bed-slot date range — drop the year
- "May 30, 2026 → June 1, 2026" now renders "May 30 → June 1".
- New \`formatGuestDateShort\` util = \`formatGuestDate\` minus the trailing \`, YYYY\`.
- The future-assignment hover tooltip keeps the full date (room there; year is useful on hover).
- 5 new tests for \`formatGuestDateShort\`.

## Verified

Browser-tested all three: faded vs. full-opacity icons clearly distinct, purple dot visibly larger, dates render "May 17→May 25". Build clean, 90 tests pass.

## Test plan

- [ ] Bed slot with notes → icon full opacity; without → barely visible
- [ ] Guest with internal notes → larger purple dot, visible at a glance
- [ ] Bed-slot date range shows no year; hover tooltip still shows full date

🤖 Generated with [Claude Code](https://claude.com/claude-code)