### PR TITLE
Fix: scope bed-slot warnings to the displayed cohort

### DIFF
--- a/src/features/dormitories/components/BedSlot.vue
+++ b/src/features/dormitories/components/BedSlot.vue
@@ -291,7 +291,14 @@ const suggestedDisplayName = computed(() => {
   return createFullName(suggestedGuest.value)
 })
 
-const warnings = computed(() => validationStore.getWarningsForBed(props.bed.bedId))
+// Scope warnings to the cohort visible at the current View Date — a
+// bed-sharer in a different (non-overlapping) cohort shouldn't surface
+// their warnings on this guest's slot. Empty slot → no warnings.
+const warnings = computed(() => {
+  const guest = assignedGuest.value
+  if (!guest) return []
+  return validationStore.getWarningsForBed(props.bed.bedId, guest.id)
+})
 
 const hasWarning = computed(() => warnings.value.length > 0)
 

--- a/src/stores/validationStore.test.ts
+++ b/src/stores/validationStore.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for cohort-scoped bed warnings.
+ *
+ * A bed can hold multiple cohorts via date-aware sharing. A warning
+ * intrinsic to one cohort's guest (e.g. "M guest in F room") must not
+ * surface on a different cohort's guest when the slot displays them.
+ * Regression guard for the "M in Female room" report against a guest
+ * who is actually female — the warning belonged to her bed-sharer.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useGuestStore } from './guestStore'
+import { useDormitoryStore } from './dormitoryStore'
+import { useAssignmentStore } from './assignmentStore'
+import { useSettingsStore } from './settingsStore'
+import { useValidationStore } from './validationStore'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+    key: () => null,
+    length: 0,
+  }
+})()
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+if (typeof globalThis.crypto === 'undefined') {
+  ;(globalThis as { crypto: Crypto }).crypto = {
+    randomUUID: () => Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`,
+  } as Crypto
+} else if (typeof globalThis.crypto.randomUUID !== 'function') {
+  globalThis.crypto.randomUUID = () =>
+    Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`
+}
+
+/**
+ * Female room, one bed, shared by two non-overlapping cohorts:
+ *   - Phyllis (F), March
+ *   - Mark (M),    April
+ * Mark in a Female room is a real gender mismatch — but it must be
+ * attributed to Mark, not to Phyllis.
+ */
+function seedSharedFemaleRoomBed() {
+  const guests = useGuestStore()
+  const phyllis = guests.addGuest({
+    firstName: 'Phyllis', lastName: 'Chen', gender: 'F', age: 45,
+    arrival: '2026-03-10', departure: '2026-03-15',
+  })
+  const mark = guests.addGuest({
+    firstName: 'Mark', lastName: 'Doe', gender: 'M', age: 50,
+    arrival: '2026-04-10', departure: '2026-04-15',
+  })
+
+  const dorm = useDormitoryStore()
+  dorm.importDormitories([
+    {
+      dormitoryName: 'Test Dorm',
+      active: true,
+      rooms: [
+        {
+          roomName: 'Female Room',
+          roomGender: 'F',
+          active: true,
+          beds: [{ bedId: 'FR01', bedType: 'single', position: 1, assignments: [] }],
+        },
+      ],
+    },
+  ])
+
+  const assign = useAssignmentStore()
+  assign.assignGuestToBed(phyllis.id, 'FR01', true)
+  assign.assignGuestToBed(mark.id, 'FR01', true)
+
+  return { phyllisId: phyllis.id, markId: mark.id }
+}
+
+describe('validationStore — cohort-scoped bed warnings', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+    // Gender-mismatch warnings are opt-in via settings; ensure on.
+    useSettingsStore().settings.warnings.genderMismatch = true
+  })
+
+  it('does NOT show the male bed-sharer\'s gender warning on the female guest\'s slot', () => {
+    const { phyllisId } = seedSharedFemaleRoomBed()
+    const validation = useValidationStore()
+
+    const warnings = validation.getWarningsForBed('FR01', phyllisId)
+    expect(warnings.some(w => /guest in F room/.test(w))).toBe(false)
+  })
+
+  it('DOES show the gender warning when the male guest is the displayed cohort', () => {
+    const { markId } = seedSharedFemaleRoomBed()
+    const validation = useValidationStore()
+
+    const warnings = validation.getWarningsForBed('FR01', markId)
+    expect(warnings.some(w => /M guest in F room/.test(w))).toBe(true)
+  })
+
+  it('unscoped call still reports every cohort (used by getAllWarnings)', () => {
+    seedSharedFemaleRoomBed()
+    const validation = useValidationStore()
+
+    const warnings = validation.getWarningsForBed('FR01')
+    expect(warnings.some(w => /M guest in F room/.test(w))).toBe(true)
+  })
+
+  it('does not report a date conflict between non-overlapping cohorts', () => {
+    const { phyllisId } = seedSharedFemaleRoomBed()
+    const validation = useValidationStore()
+
+    // March and April stays don't overlap — sharing the bed is legal.
+    const warnings = validation.getWarningsForBed('FR01', phyllisId)
+    expect(warnings.some(w => /Date conflict/.test(w))).toBe(false)
+  })
+})

--- a/src/stores/validationStore.ts
+++ b/src/stores/validationStore.ts
@@ -20,8 +20,22 @@ export const useValidationStore = defineStore('validation', () => {
   const settingsStore = useSettingsStore()
 
   // Getters
+  /**
+   * Warnings for a bed.
+   *
+   * A bed can hold multiple cohorts (date-aware sharing). Pass
+   * `displayedGuestId` to scope warnings to the cohort currently shown
+   * in the slot: gender/age/bunk warnings come only from that guest,
+   * and date conflicts are reported only for stays that collide with
+   * theirs. Without it (e.g. the global `getAllWarnings` scan) every
+   * cohort on the bed is considered.
+   *
+   * Scoping matters because, e.g., a male guest sharing a bed with a
+   * female guest in a non-overlapping cohort would otherwise surface
+   * his "M guest in F room" warning on her slot.
+   */
   const getWarningsForBed = computed(() => {
-    return (bedId: string): string[] => {
+    return (bedId: string, displayedGuestId?: string): string[] => {
       const bed = dormitoryStore.getBedById(bedId)
       // Defensive: legacy beds might lack `assignments` until migration
       // finishes; treat as empty rather than crashing.
@@ -31,12 +45,34 @@ export const useValidationStore = defineStore('validation', () => {
       const room = dormitoryStore.getRoomByBedId(bedId)
       if (!room) return []
 
-      const warnings: string[] = []
-
-      // Date-overlap warning: any pair of assignments whose stays overlap.
       const guests = bedAssignments
         .map(a => guestStore.getGuestById(a.guestId))
         .filter((g): g is Guest => g !== undefined)
+
+      const displayedGuest = displayedGuestId
+        ? guests.find(g => g.id === displayedGuestId)
+        : undefined
+
+      const warnings: string[] = []
+
+      if (displayedGuest) {
+        // Cohort-scoped: only the displayed guest's stay/room warnings.
+        const overlappingNames: string[] = []
+        for (const other of guests) {
+          if (other === displayedGuest) continue
+          if (staysOverlap(displayedGuest, other)) {
+            const name = other.preferredName || other.firstName
+            if (!overlappingNames.includes(name)) overlappingNames.push(name)
+          }
+        }
+        if (overlappingNames.length > 0) {
+          warnings.push(`Date conflict: overlaps with ${overlappingNames.join(', ')}`)
+        }
+        warnings.push(...getAssignmentWarnings(displayedGuest, bed, room))
+        return warnings
+      }
+
+      // Unscoped: every cohort on the bed (used by getAllWarnings).
       const overlappingNames: string[] = []
       for (let i = 0; i < guests.length; i++) {
         for (let j = i + 1; j < guests.length; j++) {
@@ -50,7 +86,6 @@ export const useValidationStore = defineStore('validation', () => {
         warnings.push(`Date conflict: overlaps with ${overlappingNames.join(', ')}`)
       }
 
-      // Per-guest gender/age/bunk warnings (deduplicated)
       const seen = new Set<string>()
       for (const guest of guests) {
         for (const w of getAssignmentWarnings(guest, bed, room)) {


### PR DESCRIPTION
## Summary

Fixes a misattributed validation warning reported in the field: a warning "M guest in F room" appeared on a guest (Phyllis Chen) who is female.

## Root cause

A bed can hold multiple cohorts via date-aware sharing. `getWarningsForBed` looped over **every** assignment on the bed and ran the per-guest gender/age/bunk checks for all of them. So when a male guest shared a bed with a female guest in a **non-overlapping cohort** (legal date-aware sharing), in a Female room:

- The male guest legitimately trips "M guest in F room".
- That warning was aggregated onto the **bed**, and `BedSlot` shows all bed warnings regardless of which cohort is currently displayed.
- Result: the female guest's slot shows a male-in-female-room warning that isn't about her.

This was hard to reproduce because it needs the specific setup — a male guest sharing the exact bed in a separate cohort, in a gendered room.

## Fix

- `getWarningsForBed(bedId, displayedGuestId?)` — new optional param. When set, gender/age/bunk warnings come only from that guest, and date conflicts are reported only for stays that collide with theirs.
- `BedSlot` passes the guest visible at the current View Date, and shows no warnings when the slot is empty at that date.
- The unscoped form (no `displayedGuestId`) is preserved for the global `getAllWarnings` scan, which should still surface every cohort's issues.

## Verified

End-to-end in the browser with the exact repro (Phyllis F / Mark M sharing a Female-room bed, non-overlapping cohorts):
- `getWarningsForBed('FR01', phyllisId)` → `[]`
- `getWarningsForBed('FR01', markId)` → `["M guest in F room"]`
- `getWarningsForBed('FR01')` → `["M guest in F room"]` (unscoped, unchanged)

4 new `validationStore` tests pin the behavior. Full suite: 94 tests pass.

## Test plan

- [ ] Female room, bed shared by a female guest (March) and a male guest (April) → female's slot shows no gender warning; male's slot does
- [ ] Set View Date into each cohort → warning follows the displayed guest
- [ ] Global warning indicators (hints) still count the male-in-female-room issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)