### PR TITLE
Suppress unassigned-row pill in All Reservations

### DIFF
--- a/src/features/guest-data/components/GuestDataView.vue
+++ b/src/features/guest-data/components/GuestDataView.vue
@@ -65,6 +65,7 @@
         :readonly="true"
         :columns="settingsStore.guestDataColumns"
         :hide-column-controls="true"
+        :pill-unassigned="false"
         empty-title="No guests loaded"
         empty-message="Upload a CSV file or load test data to get started."
       />

--- a/src/features/guests/components/GuestList.vue
+++ b/src/features/guests/components/GuestList.vue
@@ -42,6 +42,7 @@
           :columns="columns"
           :family-position="getFamilyPosition(guest, index)"
           :readonly="props.readonly"
+          :pill-unassigned="props.pillUnassigned"
           @edit="handleEditGuest"
         />
         <tr v-if="guests.length === 0" class="empty-row">
@@ -176,6 +177,9 @@ interface Props {
   columns: ColumnConfig[]
   viewDate?: Date | null
   hideColumnControls?: boolean
+  // Forward to GuestRow — see its prop docs. Defaults to true to keep
+  // the unassigned-guest pill in the Table View left panel.
+  pillUnassigned?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -185,6 +189,7 @@ const props = withDefaults(defineProps<Props>(), {
   readonly: false,
   viewDate: null,
   hideColumnControls: false,
+  pillUnassigned: true,
 })
 
 const guestStore = useGuestStore()

--- a/src/features/guests/components/GuestRow.vue
+++ b/src/features/guests/components/GuestRow.vue
@@ -1,6 +1,6 @@
 <template>
   <tr
-    :class="['guest-row', { 'picked-up': isPickedUp, 'is-picked': isPicked, 'is-pick-target': isPickTarget, 'has-suggestion': hasSuggestion, 'link-target': isLinkTarget, 'selected-for-linking': isSelectedForLinking, 'group-highlight': isGroupHighlighted, 'group-dimmed': isGroupDimmed, 'is-unassigned': isUnassigned, 'non-assignable': !isAssignable, 'is-cancelled': guest.isCancelled }]"
+    :class="['guest-row', { 'picked-up': isPickedUp, 'is-picked': isPicked, 'is-pick-target': isPickTarget, 'has-suggestion': hasSuggestion, 'link-target': isLinkTarget, 'selected-for-linking': isSelectedForLinking, 'group-highlight': isGroupHighlighted, 'group-dimmed': isGroupDimmed, 'is-unassigned': pillUnassigned && isUnassigned, 'non-assignable': !isAssignable, 'is-cancelled': guest.isCancelled }]"
     v-bind="draggableProps"
     @click="handleRowClick"
   >
@@ -184,6 +184,12 @@ interface Props {
   columns: ColumnConfig[]
   familyPosition?: 'none' | 'first' | 'middle' | 'last' | 'only'
   readonly?: boolean
+  // Visually pill unassigned rows (light grey background, rounded
+  // corners, vertical gaps). Intended for the unassigned-guests panel
+  // in Table View where the pill helps unassigned guests pop. The All
+  // Reservations table opts out — assigned/unassigned isn't the first
+  // question there and the pill leaks visual noise into a dense table.
+  pillUnassigned?: boolean
 }
 
 interface Emits {
@@ -193,6 +199,7 @@ interface Emits {
 const props = withDefaults(defineProps<Props>(), {
   familyPosition: 'none',
   readonly: false,
+  pillUnassigned: true,
 })
 
 const emit = defineEmits<Emits>()


### PR DESCRIPTION
## Summary

Stops All Reservations rendering every unassigned guest with the grey "pill" treatment that was designed for the Table View left panel.

## What was happening

The \`is-unassigned\` class on \`GuestRow\` gives unassigned guests a light-grey background (\`#e5e7eb\`), a rounded border, and small vertical gaps — designed for the unassigned-guest panel in Table View where it helps unassigned guests pop. \`GuestRow\` is reused in All Reservations, so the pill leaked there too. The result: most rows in All Reservations rendered grey (which, photographed under warm room light, even read as pink to one operator), making it look like the table was highlighting things.

## Fix

New \`pillUnassigned\` prop on \`GuestRow\` and \`GuestList\` (default \`true\` to preserve existing Table View behavior). \`GuestDataView\` (the All Reservations table) passes \`false\`.

## Verified

Build clean, 95 tests pass. No behavior change in Table View.

## Test plan

- [ ] Table View → "Unassigned Guests" left panel still pills unassigned guests
- [ ] All Reservations → all rows now render flat (no grey pill, no rounded gaps)
- [ ] Cancelled rows still get the opacity / strikethrough treatment in both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)