### PR TITLE
Time-based room overrides: data layer (PR 1/3)

### DIFF
--- a/specs/TimeBasedRoomConfig.md
+++ b/specs/TimeBasedRoomConfig.md
@@ -1,0 +1,256 @@
+# Spec: Time-Based Room Configuration
+
+**Status:** Draft
+**Date:** 2026-06-13
+**Supersedes (partially):** [`MultipleRoomLayouts.md`](./MultipleRoomLayouts.md) — that spec landed a manual layout-switching model (`layouts` + `activeLayoutId` in `dormitoryStore`) that clears assignments on switch. This spec replaces the switching model with a time-aware overlay model that never clears assignments.
+
+## Purpose & User Problem
+
+The monastery's dorm layout isn't static. Two real-world patterns:
+
+1. **Recurring retreat configurations** — for a women's retreat, certain dorms switch to female-only; for a small retreat, half the buildings close. These repeat.
+2. **One-off operational tweaks** — a heater breaks so a single bed goes offline; a family of 5 arrives and a coed dorm temporarily becomes family-only; a building closes early for cleaning.
+
+The existing `RoomLayout` model handles #1 awkwardly (every preset is a full snapshot — edits drift) and #2 not at all (you'd clone a layout to flip one bed). Worse, switching layouts **clears assignments**, which makes the feature unusable mid-retreat-cycle when you already have a month of bookings on the board.
+
+What's actually needed: a single base configuration plus **dated overrides** that change attributes for a date window. Overrides:
+- propagate **forward** in time (never retroactively rewrite a past day)
+- compose with **date-aware bed sharing** (the existing `staysOverlap` model already speaks this language)
+- can be bundled into named **presets** for repeating patterns
+- can be applied one-off without touching any preset
+
+## Current State
+
+- `dormitoryStore`: `dormitories: Dormitory[]` + `layouts: RoomLayout[]` + `activeLayoutId`. Switching layouts swaps the working `dormitories` array and **clears all assignments** (per the older spec).
+- `dormitory.active: boolean`, `room.active: boolean`, `room.gender: 'M' | 'F' | 'Coed'`, `bed.active: boolean` — all single-valued, atemporal.
+- Table View has a **View Date** filter (`dormAssignments-viewDate`) that scopes the bed slots to a single day so multi-cohort beds resolve to one displayed guest. This already establishes "the app has a current temporal lens."
+- Validation, auto-placement, and availability checks are already date-aware via `staysOverlap` (half-open intervals; missing dates = always present).
+- The old `RoomLayout` UI is wired in Room Configuration tab.
+
+## Proposed Model
+
+### Core concept: Base config + dated override events
+
+```
+Effective config @ date D  =  base dormitories[]  +  reduce(overrides effective on D)
+```
+
+Each override is one event that changes one attribute on one target for a date window:
+
+```typescript
+type OverrideTarget =
+  | { kind: 'dormitory'; dormitoryName: string }
+  | { kind: 'room'; bedIdPrefix: string }   // rooms identified by their bedId prefix
+  | { kind: 'bed'; bedId: string }
+
+type OverrideAttribute =
+  | { attr: 'active'; value: boolean }
+  | { attr: 'gender'; value: 'M' | 'F' | 'Coed' }   // room only
+
+interface ConfigOverride {
+  id: string                    // UUID
+  target: OverrideTarget
+  change: OverrideAttribute
+  effectiveFrom: string         // ISO date, inclusive
+  effectiveTo: string | null    // ISO date, inclusive; null = open-ended
+  presetId: string | null       // null = one-off; set = part of a preset bundle
+  note?: string                 // operator-entered reason ("heater broken", "Women's retreat")
+  createdAt: string
+}
+```
+
+**Cascading** (per interview): closing a dorm cascades to its rooms and beds **by default**, but a same-window override that re-opens a specific room/bed wins. Resolution order at any date D:
+1. Start from base config.
+2. Apply dorm-level overrides effective on D.
+3. Apply room-level overrides effective on D (overrides dorm cascade).
+4. Apply bed-level overrides effective on D (overrides room cascade).
+5. Gender overrides: room-level only, applied last.
+
+Conflicting overrides at the same level on the same target/date are resolved by **most-recently-created wins**, with a warning surfaced in the override list.
+
+### Presets
+
+```typescript
+interface OverridePreset {
+  id: string                    // UUID
+  name: string                  // "Women's Retreat", "Winter Mode", "Small Retreat"
+  description?: string
+  createdAt: string
+  updatedAt: string
+}
+```
+
+A preset is just a **named bundle**. Overrides reference it via `presetId`. Applying a preset = creating its overrides for a chosen date window. Reverting = deleting all overrides with that `presetId`.
+
+Crucially: presets don't store a snapshot. They're a template that emits override events when applied. This keeps the historical record of what was *actually* applied (and lets you tweak one preset application without affecting other applications of the same preset).
+
+### Effective-config derivation
+
+A new computed in `dormitoryStore`:
+
+```typescript
+const dormitoriesAt = computed(() => (date: string | null): Dormitory[] => { ... })
+```
+
+- `dormitoriesAt(null)` → base config (admin/edit view).
+- `dormitoriesAt('2026-07-04')` → effective config that day, with overrides applied.
+
+The current single-date `dormitories` ref is preserved as the **base** (edit target for "permanent" changes). Existing getters like `getAllRooms`, `getAllBeds`, `getBedById` get a date parameter (or read the current View Date by default).
+
+### Composition with bed sharing
+
+A bed is available for a guest's stay `[arrival, departure)` iff:
+1. For every day D in that stay, `dormitoriesAt(D)` shows the bed as `active`, its room as `active`, its dorm as `active`.
+2. The room's gender on D is compatible with the guest's gender (using existing room-gender rules).
+3. No existing `BedAssignment` cohort overlaps the candidate stay (existing rule).
+
+Implementation: a new helper `isBedActiveDuringStay(bedId, arrival, departure)` walks the override list. Auto-placement helpers (`getAvailableBeds`, `isBedAvailableForGuest`, `isBedAvailableForGroup`) call it before delegating to existing checks.
+
+## UX
+
+Per interview: **View Date + Preset picker**.
+
+### Table View (existing)
+- View Date already exists. Bed slots, room headers, dorm headers render from `dormitoriesAt(viewDate)`.
+- New visual: rooms/beds that are inactive on the View Date render with a hatched/disabled style + a tooltip showing which override caused it ("Closed by 'Winter Mode' preset, May 1 – Sep 1").
+- Gender-overridden rooms show their effective gender with a small "📅 override" badge.
+
+### Room Configuration tab — new "Overrides" sub-section
+Below the existing dormitory editor (which edits the **base** config), add:
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  Active Presets                          [+ New Preset]   │
+│  ┌──────────────────────────────────────────────────────┐ │
+│  │ ◉ Women's Retreat   Jul 4 → Jul 11   [Apply][Edit] │ │
+│  │ ○ Winter Mode       (template only)   [Apply][Edit] │ │
+│  └──────────────────────────────────────────────────────┘ │
+├────────────────────────────────────────────────────────────┤
+│  Overrides (timeline)         Filter: [All] [Active] [...] │
+│  ┌──────────────────────────────────────────────────────┐ │
+│  │ Jul 4 – Jul 11  Maple Hall    Gender → F   [Women's]│ │
+│  │ Jul 4 – Jul 11  Maple Hall B  Closed       [Women's]│ │
+│  │ Aug 12 → ∞      Bed MA03      Closed       [one-off]│ │
+│  └──────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────┘
+```
+
+- **Presets list** — create / edit / delete preset templates. Editing a preset opens a modal where you check off targets + attributes (e.g. "Maple Hall: gender → F", "North Building: closed"). The template is a list of `(target, change)` pairs without dates.
+- **Apply preset** — modal prompts for `effectiveFrom` + `effectiveTo`. Emits one override per template entry, all tagged with this preset's id and this application's date window. Conflicts with existing assignments are surfaced (see below).
+- **Overrides timeline** — flat list of every override (preset + one-off). Each row shows window, target, change, source (preset name or "one-off"), and delete button. One-off creation: a `+ Add Override` form (target picker, attribute, dates, optional note).
+- **Revert preset application** — one-click "Revert" button on a preset row when it's currently applied; deletes all overrides with that `presetId` within the applied window.
+
+### One-off override from Table View
+Right-click on a bed/room header → "Add override here..." → opens the override form pre-filled with that target and `effectiveFrom = today, effectiveTo = null`. Lets operators make on-the-fly changes without leaving Table View.
+
+### Conflict surfacing (per interview: warn + list, allow but flag)
+When applying an override (preset or one-off) that affects beds with **existing assignments inside the override window**:
+
+1. Pre-application dialog (modeled on `ImportSummaryDialog`):
+   ```
+   Applying "Women's Retreat" Jul 4 – Jul 11 will affect 3 existing assignments:
+
+   Maple Hall B (Closed):
+     - Sarah Chen (Jul 5 – Jul 9)
+     - Tom Park (Jul 4 – Jul 8)
+
+   Maple Hall (gender → F):
+     - Bob Lee (Jul 6 – Jul 11) — male in female room
+
+   [Cancel]  [Apply anyway]
+   ```
+2. On "Apply anyway": overrides are written, affected assignments **are not auto-unassigned**. They show up with a new validation warning category `'overrideConflict'` so the operator can re-place them at their own pace.
+3. A new bed-slot badge ⚠️ surfaces the warning at the slot.
+
+## Migration from existing `RoomLayout`
+
+The old layout-switching model is in production. Migration plan:
+
+1. **One-time migration on first load** after this ships:
+   - If `layouts.length > 1`: prompt the operator with a one-time dialog:
+     > "You have N saved layouts. The new model uses one base configuration with dated overrides instead. Pick which existing layout should become the base — the others will be converted into preset templates you can apply by date."
+   - Operator picks one → that becomes `dormitories` (base). The others get converted: a structural diff vs. the chosen base produces preset templates (e.g. layout "Winter Mode" → preset "Winter Mode" with overrides like "North Building: active → false", "Pine Room: gender → F").
+   - If `layouts.length === 1` (or 0): trivially migrate; that layout's data is already the base.
+2. **Keep `RoomLayout` types and `dormitoryStore.layouts` array intact for one release** to allow rollback. Mark deprecated.
+3. **JSON export format** gets a new top-level `overrides` and `presets` arrays alongside `dormitories`. CSV export of the base config still works (unchanged shape, just exports `dormitoriesAt(null)`).
+
+## Scope
+
+### In Scope
+- New types: `ConfigOverride`, `OverridePreset`, `OverrideTarget`, `OverrideAttribute`.
+- New `dormitoryStore` state: `overrides: ConfigOverride[]`, `presets: OverridePreset[]`, computed `dormitoriesAt(date)`, helper `isBedActiveDuringStay(bedId, arrival, departure)`.
+- Cascading resolution (dorm → room → bed) with same-level conflict warning (most-recent-wins).
+- Room Configuration tab: Presets list + Overrides timeline (CRUD).
+- Apply / revert preset flow with conflict dialog.
+- Right-click "Add override" from Table View bed/room headers.
+- Visual hatching for inactive-on-this-date rooms/beds + gender-override badge in Table View.
+- New validation category `overrideConflict` (gender / closed-bed / closed-room mismatches on existing assignments).
+- Auto-placement + availability check integration via `isBedActiveDuringStay`.
+- Migration from existing multi-layout state.
+- JSON export/import extension (`overrides`, `presets`).
+- localStorage persistence (per-store, additive: `overrides`, `presets` paths added to existing `dormAssignments-dormitories`).
+
+### Out of Scope (future)
+- Adding **new** rooms or beds via overrides (e.g. temporary tent for one retreat). Overrides only toggle attributes on existing entities. If the user later wants temp-rooms, that's a follow-up spec.
+- Preset versioning / history of edits.
+- Calendar visualization of overrides (the flat timeline list is v1).
+- Recurring overrides ("every Tuesday Maple Hall closes for cleaning") — v1 is single-window only.
+- Sharing presets between installations (beyond JSON export).
+- Per-cohort or per-guest overrides (e.g. "this guest needs a specific room"). Overrides are room/bed/dorm-level only.
+
+## Technical Considerations
+
+### Affected files
+- `src/types/Overrides.ts` (new) — `ConfigOverride`, `OverridePreset`, `OverrideTarget`, `OverrideAttribute`.
+- `src/types/index.ts` — re-export.
+- `src/stores/dormitoryStore.ts` — new state, `dormitoriesAt` computed, override CRUD, preset CRUD + apply/revert, migration logic.
+- `src/stores/validationStore.ts` — new `overrideConflict` category; existing date-scoped checks read effective config via `dormitoriesAt`.
+- `src/features/assignments/composables/useAutoPlacement.ts` — availability helpers call `isBedActiveDuringStay`.
+- `src/shared/composables/useDropValidation.ts` — same.
+- `src/features/dormitories/components/RoomConfigCard.vue` — base editor unchanged.
+- `src/features/dormitories/components/OverrideTimeline.vue` (new) — list + form for overrides.
+- `src/features/dormitories/components/PresetList.vue` (new) — preset CRUD + apply.
+- `src/features/dormitories/components/PresetEditModal.vue` (new) — checkbox grid of (target × attribute) for editing a preset template.
+- `src/features/dormitories/components/ApplyPresetModal.vue` (new) — date-range picker + conflict preview.
+- `src/features/dormitories/components/BedSlot.vue` — read effective config at View Date; show hatch / override badge.
+- `src/features/dormitories/components/RoomList.vue` — same.
+- `src/features/timeline/components/TimelineView.vue` — honor effective config across the timeline range.
+- `src/features/print/components/PrintView.vue` — print views render using effective config (per-page date is already filtered).
+- `src/features/csv/components/RoomConfigCSV.vue` — JSON export/import handles new fields.
+
+### Performance
+- `dormitoriesAt(date)` is computed per (date, overrides-version). Memoize by date string — most lookups in a session hit a small set of dates (View Date + each guest's stay days).
+- Bed availability check during auto-placement walks the override list per stay. Override count is small (dozens, not thousands) — linear scan is fine.
+
+### Data safety
+- Overrides are append-only from the user's POV: editing an override = delete + re-create (preserves an audit-friendly model).
+- Migration is one-shot, gated by a one-time dialog.
+- All conflict-producing actions (apply preset, add override that affects an assignment) prompt before commit.
+
+### Persistence
+Extend existing `dormAssignments-dormitories` key:
+```ts
+paths: ['dormitories', 'configName', 'layouts', 'activeLayoutId', 'bedShapeVersion', 'overrides', 'presets']
+```
+
+## Success Criteria
+
+- [ ] Adding a one-off override (close one bed Aug 12 → ∞) immediately marks that bed inactive on Table View when View Date ≥ Aug 12, and leaves it active before then.
+- [ ] Defining a preset with multiple targets (close North Building, switch Maple Hall to F) and applying it for a date range emits all the right overrides, all tagged with the preset id.
+- [ ] Reverting an applied preset removes only overrides from that application; other presets' overrides are untouched.
+- [ ] Cascade works: closing a dorm marks its rooms/beds inactive *unless* a same-window override re-opens a specific room or bed.
+- [ ] Gender override on a room shows the new gender on Table View at the override window and reverts after.
+- [ ] Auto-placement skips beds whose rooms/dorms/themselves are inactive during the candidate's stay.
+- [ ] Pre-apply conflict dialog lists every affected assignment with name + dates + reason.
+- [ ] Applying anyway: overrides written, affected assignments stay put with new `overrideConflict` warning.
+- [ ] Right-click "Add override" from Table View bed/room/dorm headers works and pre-fills the target.
+- [ ] JSON export round-trips `overrides` and `presets`.
+- [ ] Migration from multi-layout state: operator picks a base, diffs become preset templates, no data lost.
+- [ ] Operating on a long-running data set (multiple months of bookings) never wipes assignments.
+
+## Open Questions
+
+1. **Cascade explicitness on revert** — if a dorm-close override has a room-open exception override at the same window, and the user reverts the dorm-close, should the room-open exception auto-delete? Proposed: keep it (no auto-delete), surface a hint that the exception is now a no-op.
+2. **Auto-place after override** — should there be a one-click "Auto-place affected guests" after applying an override that breaks assignments? Could be a v1.5 add.
+3. **Print views during override windows** — should the Guestmaster / Work Coordinator print omit closed rooms entirely, or list them with a "(closed)" marker? Proposed: omit entirely from list-by-dorm; still show in counts header.
+4. **CSV export of base** — should overrides export to CSV at all? Proposed: no, JSON only for overrides. CSV remains a base-config-only format for backwards compat with operators sharing spreadsheets.

--- a/src/stores/dormitoryStore.overrides.test.ts
+++ b/src/stores/dormitoryStore.overrides.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Tests for time-based room configuration overrides.
+ *
+ * Covers `dormitoriesAt(date)` resolution (including cascade + exception
+ * wins), `isBedActiveDuringStay` over a stay window, gender overrides,
+ * and the preset apply/revert lifecycle. See `specs/TimeBasedRoomConfig.md`.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useDormitoryStore } from './dormitoryStore'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+    key: () => null,
+    length: 0,
+  }
+})()
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+if (typeof globalThis.crypto === 'undefined') {
+  ;(globalThis as { crypto: Crypto }).crypto = {
+    randomUUID: () => Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`,
+  } as Crypto
+} else if (typeof globalThis.crypto.randomUUID !== 'function') {
+  globalThis.crypto.randomUUID = () =>
+    Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`
+}
+
+/**
+ * Two dorms, two rooms each. Maple Hall is mixed-gender (room A is M,
+ * room B is F). Pine Cabin has a single coed family room.
+ */
+function seedBaseTree() {
+  const dorm = useDormitoryStore()
+  dorm.importDormitories([
+    {
+      dormitoryName: 'Maple Hall',
+      active: true,
+      rooms: [
+        {
+          roomName: 'Room A',
+          roomGender: 'M',
+          active: true,
+          beds: [
+            { bedId: 'MA1', bedType: 'lower', assignments: [], position: 1 },
+            { bedId: 'MA2', bedType: 'upper', assignments: [], position: 2 },
+          ],
+        },
+        {
+          roomName: 'Room B',
+          roomGender: 'F',
+          active: true,
+          beds: [
+            { bedId: 'MB1', bedType: 'single', assignments: [], position: 1 },
+          ],
+        },
+      ],
+    },
+    {
+      dormitoryName: 'Pine Cabin',
+      active: true,
+      rooms: [
+        {
+          roomName: 'Family Room',
+          roomGender: 'Coed',
+          active: true,
+          beds: [
+            { bedId: 'PF1', bedType: 'single', assignments: [], position: 1 },
+            { bedId: 'PF2', bedType: 'single', assignments: [], position: 2 },
+          ],
+        },
+      ],
+    },
+  ])
+  return dorm
+}
+
+describe('dormitoryStore.dormitoriesAt — base passthrough', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('with no overrides returns the base tree unchanged', () => {
+    const dorm = seedBaseTree()
+    const result = dorm.dormitoriesAt(null)
+    expect(result).toEqual(dorm.dormitories)
+  })
+
+  it('with no overrides at a date returns the same shape as base', () => {
+    const dorm = seedBaseTree()
+    const result = dorm.dormitoriesAt('2026-07-01')
+    expect(result.length).toBe(2)
+    expect(result[0].rooms[0].active).toBe(true)
+  })
+})
+
+describe('dormitoryStore.dormitoriesAt — cascade resolution', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('closing a dormitory cascades to its rooms and beds', () => {
+    const dorm = seedBaseTree()
+    dorm.addOverride({
+      target: { kind: 'dormitory', dormitoryName: 'Maple Hall' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-04',
+      effectiveTo: '2026-07-11',
+    })
+
+    const inWindow = dorm.dormitoriesAt('2026-07-06')
+    const maple = inWindow.find(d => d.dormitoryName === 'Maple Hall')!
+    expect(maple.active).toBe(false)
+    expect(maple.rooms.every(r => !r.active)).toBe(true)
+    expect(maple.rooms.flatMap(r => r.beds).every(b => b.active === false)).toBe(true)
+
+    // Outside the window, base is restored.
+    const outside = dorm.dormitoriesAt('2026-08-01')
+    expect(outside.find(d => d.dormitoryName === 'Maple Hall')!.active).toBe(true)
+  })
+
+  it('room-level exception wins over a dorm-close cascade', () => {
+    const dorm = seedBaseTree()
+    dorm.addOverride({
+      target: { kind: 'dormitory', dormitoryName: 'Maple Hall' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-04',
+      effectiveTo: '2026-07-11',
+    })
+    dorm.addOverride({
+      target: { kind: 'room', dormitoryName: 'Maple Hall', roomName: 'Room A' },
+      change: { attr: 'active', value: true },
+      effectiveFrom: '2026-07-04',
+      effectiveTo: '2026-07-11',
+    })
+
+    const result = dorm.dormitoriesAt('2026-07-06')
+    const maple = result.find(d => d.dormitoryName === 'Maple Hall')!
+    // Dorm bubbles back to active so iteration finds the exception room.
+    expect(maple.active).toBe(true)
+    expect(maple.rooms.find(r => r.roomName === 'Room A')!.active).toBe(true)
+    expect(maple.rooms.find(r => r.roomName === 'Room B')!.active).toBe(false)
+  })
+
+  it('bed-level exception wins over a room-close cascade', () => {
+    const dorm = seedBaseTree()
+    dorm.addOverride({
+      target: { kind: 'room', dormitoryName: 'Maple Hall', roomName: 'Room A' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-08-12',
+      effectiveTo: null,
+    })
+    dorm.addOverride({
+      target: { kind: 'bed', bedId: 'MA1' },
+      change: { attr: 'active', value: true },
+      effectiveFrom: '2026-08-12',
+      effectiveTo: null,
+    })
+
+    const result = dorm.dormitoriesAt('2026-09-01')
+    const roomA = result[0].rooms.find(r => r.roomName === 'Room A')!
+    expect(roomA.active).toBe(true)
+    expect(roomA.beds.find(b => b.bedId === 'MA1')!.active).toBe(true)
+    expect(roomA.beds.find(b => b.bedId === 'MA2')!.active).toBe(false)
+  })
+
+  it('most-recent override wins among same-target same-attr conflicts', async () => {
+    const dorm = seedBaseTree()
+    dorm.addOverride({
+      target: { kind: 'bed', bedId: 'MA1' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-04',
+      effectiveTo: '2026-07-11',
+    })
+    // tiny delay so createdAt differs
+    await new Promise(r => setTimeout(r, 5))
+    dorm.addOverride({
+      target: { kind: 'bed', bedId: 'MA1' },
+      change: { attr: 'active', value: true },
+      effectiveFrom: '2026-07-04',
+      effectiveTo: '2026-07-11',
+    })
+
+    const result = dorm.dormitoriesAt('2026-07-06')
+    const bed = result[0].rooms[0].beds.find(b => b.bedId === 'MA1')!
+    expect(bed.active).toBe(true)
+  })
+})
+
+describe('dormitoryStore.dormitoriesAt — gender override', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('changes a room\'s effective gender within the window only', () => {
+    const dorm = seedBaseTree()
+    dorm.addOverride({
+      target: { kind: 'room', dormitoryName: 'Maple Hall', roomName: 'Room A' },
+      change: { attr: 'gender', value: 'F' },
+      effectiveFrom: '2026-07-04',
+      effectiveTo: '2026-07-11',
+    })
+
+    expect(dorm.roomGenderAt('Maple Hall', 'Room A', '2026-07-06')).toBe('F')
+    expect(dorm.roomGenderAt('Maple Hall', 'Room A', '2026-07-12')).toBe('M')
+    expect(dorm.roomGenderAt('Maple Hall', 'Room A', '2026-07-03')).toBe('M')
+  })
+})
+
+describe('dormitoryStore.isBedActiveDuringStay', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('returns true when the entire stay is outside any inactive window', () => {
+    const dorm = seedBaseTree()
+    dorm.addOverride({
+      target: { kind: 'bed', bedId: 'MA1' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-08-12',
+      effectiveTo: null,
+    })
+    // Stay ends before the override begins.
+    expect(dorm.isBedActiveDuringStay('MA1', '2026-07-04', '2026-07-11')).toBe(true)
+  })
+
+  it('returns false if the stay overlaps an inactive bed window at any point', () => {
+    const dorm = seedBaseTree()
+    dorm.addOverride({
+      target: { kind: 'bed', bedId: 'MA1' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-08',
+      effectiveTo: '2026-07-10',
+    })
+    expect(dorm.isBedActiveDuringStay('MA1', '2026-07-09', '2026-07-15')).toBe(false)
+    expect(dorm.isBedActiveDuringStay('MA1', '2026-07-04', '2026-07-09')).toBe(false)
+  })
+
+  it('honors the half-open convention (departure day is bed-available)', () => {
+    const dorm = seedBaseTree()
+    dorm.addOverride({
+      target: { kind: 'bed', bedId: 'MA1' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-08',
+      effectiveTo: null,
+    })
+    // Departing the morning of the 8th means the guest didn't sleep on the 8th.
+    expect(dorm.isBedActiveDuringStay('MA1', '2026-07-04', '2026-07-08')).toBe(true)
+  })
+
+  it('respects a dorm-level close cascading down to the bed', () => {
+    const dorm = seedBaseTree()
+    dorm.addOverride({
+      target: { kind: 'dormitory', dormitoryName: 'Maple Hall' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-04',
+      effectiveTo: '2026-07-11',
+    })
+    expect(dorm.isBedActiveDuringStay('MA1', '2026-07-04', '2026-07-08')).toBe(false)
+    expect(dorm.isBedActiveDuringStay('MA1', '2026-07-12', '2026-07-15')).toBe(true)
+  })
+})
+
+describe('dormitoryStore — preset apply/revert', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('applyPreset emits one override per template entry, all tagged with the same applicationId', () => {
+    const dorm = seedBaseTree()
+    const preset = dorm.addPreset({
+      name: "Women's Retreat",
+      entries: [
+        {
+          target: { kind: 'room', dormitoryName: 'Maple Hall', roomName: 'Room A' },
+          change: { attr: 'gender', value: 'F' },
+        },
+        {
+          target: { kind: 'dormitory', dormitoryName: 'Pine Cabin' },
+          change: { attr: 'active', value: false },
+        },
+      ],
+    })
+
+    const applicationId = dorm.applyPreset(preset.id, '2026-07-04', '2026-07-11')
+    expect(applicationId).not.toBeNull()
+    const emitted = dorm.overrides.filter(o => o.applicationId === applicationId)
+    expect(emitted.length).toBe(2)
+    expect(emitted.every(o => o.presetId === preset.id)).toBe(true)
+    expect(emitted.every(o => o.effectiveFrom === '2026-07-04')).toBe(true)
+    expect(emitted.every(o => o.effectiveTo === '2026-07-11')).toBe(true)
+  })
+
+  it('revertPresetApplication deletes only that application\'s overrides', () => {
+    const dorm = seedBaseTree()
+    const preset = dorm.addPreset({
+      name: "Women's Retreat",
+      entries: [
+        {
+          target: { kind: 'dormitory', dormitoryName: 'Pine Cabin' },
+          change: { attr: 'active', value: false },
+        },
+      ],
+    })
+
+    const appA = dorm.applyPreset(preset.id, '2026-07-04', '2026-07-11')!
+    const appB = dorm.applyPreset(preset.id, '2026-08-01', '2026-08-08')!
+    expect(dorm.overrides.length).toBe(2)
+
+    const removed = dorm.revertPresetApplication(appA)
+    expect(removed).toBe(1)
+    expect(dorm.overrides.length).toBe(1)
+    expect(dorm.overrides[0].applicationId).toBe(appB)
+  })
+
+  it('deletePreset removes the preset AND all overrides emitted from it', () => {
+    const dorm = seedBaseTree()
+    const preset = dorm.addPreset({
+      name: 'Winter Mode',
+      entries: [
+        {
+          target: { kind: 'dormitory', dormitoryName: 'Pine Cabin' },
+          change: { attr: 'active', value: false },
+        },
+      ],
+    })
+    dorm.applyPreset(preset.id, '2026-12-01', '2027-03-01')
+    expect(dorm.overrides.length).toBe(1)
+
+    dorm.deletePreset(preset.id)
+    expect(dorm.presets.find(p => p.id === preset.id)).toBeUndefined()
+    expect(dorm.overrides.length).toBe(0)
+  })
+
+  it('applyPreset on a missing preset returns null and emits nothing', () => {
+    const dorm = seedBaseTree()
+    const before = dorm.overrides.length
+    const result = dorm.applyPreset('nonexistent-id', '2026-07-04', '2026-07-11')
+    expect(result).toBeNull()
+    expect(dorm.overrides.length).toBe(before)
+  })
+})
+
+describe('dormitoryStore — date range validation', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('addOverride throws on a backwards date range', () => {
+    const dorm = seedBaseTree()
+    expect(() =>
+      dorm.addOverride({
+        target: { kind: 'bed', bedId: 'MA1' },
+        change: { attr: 'active', value: false },
+        effectiveFrom: '2026-07-11',
+        effectiveTo: '2026-07-04',
+      })
+    ).toThrow(/effectiveTo.*before.*effectiveFrom/)
+    expect(dorm.overrides.length).toBe(0)
+  })
+
+  it('addOverride accepts open-ended (null effectiveTo)', () => {
+    const dorm = seedBaseTree()
+    expect(() =>
+      dorm.addOverride({
+        target: { kind: 'bed', bedId: 'MA1' },
+        change: { attr: 'active', value: false },
+        effectiveFrom: '2026-07-11',
+        effectiveTo: null,
+      })
+    ).not.toThrow()
+  })
+})
+
+describe('dormitoryStore — open-ended overrides', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('null effectiveTo means open-ended forward', () => {
+    const dorm = seedBaseTree()
+    dorm.addOverride({
+      target: { kind: 'bed', bedId: 'MA1' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-08-12',
+      effectiveTo: null,
+    })
+
+    expect(dorm.isBedActiveOn('MA1', '2026-08-12')).toBe(false)
+    expect(dorm.isBedActiveOn('MA1', '2027-01-01')).toBe(false)
+    // Before the effective date the base still wins.
+    expect(dorm.isBedActiveOn('MA1', '2026-08-11')).toBe(true)
+  })
+})

--- a/src/stores/dormitoryStore.ts
+++ b/src/stores/dormitoryStore.ts
@@ -4,9 +4,24 @@
  */
 
 import { defineStore } from 'pinia'
-import { ref, computed, watch, nextTick } from 'vue'
-import type { Dormitory, DormitoryInput, Room, RoomInput, Bed, FlatRoom, RoomLayout } from '@/types'
+import { ref, computed, watch, nextTick, toRaw } from 'vue'
+import type {
+  Dormitory,
+  DormitoryInput,
+  Room,
+  RoomInput,
+  Bed,
+  FlatRoom,
+  RoomLayout,
+  ConfigOverride,
+  OverridePreset,
+  OverrideTarget,
+  OverrideAttribute,
+  PresetTemplateEntry,
+  RoomGender,
+} from '@/types'
 import { DEFAULT_COLORS } from '@/types'
+import { parseLocalDate } from '@/shared/composables/useUtils'
 
 /**
  * Bed-shape schema version. Bump when changing bed structure so migration
@@ -30,6 +45,10 @@ export const useDormitoryStore = defineStore(
     // Layout state
     const layouts = ref<RoomLayout[]>([])
     const activeLayoutId = ref<string | null>(null)
+
+    // Time-based overrides + presets (see specs/TimeBasedRoomConfig.md)
+    const overrides = ref<ConfigOverride[]>([])
+    const presets = ref<OverridePreset[]>([])
 
     // Internal flag to suppress auto-save during layout switch
     let _suppressAutoSave = false
@@ -544,6 +563,350 @@ export const useDormitoryStore = defineStore(
       }
     }
 
+    // --- Time-based Overrides + Presets ---
+
+    /**
+     * True if `date` falls within `[effectiveFrom, effectiveTo]` (inclusive
+     * on both ends; `effectiveTo === null` = open-ended).
+     */
+    function isOverrideActiveOn(override: ConfigOverride, date: string): boolean {
+      const d = parseLocalDate(date)
+      if (isNaN(d.getTime())) return false
+      const from = parseLocalDate(override.effectiveFrom)
+      if (isNaN(from.getTime())) return false
+      if (d < from) return false
+      if (override.effectiveTo === null) return true
+      const to = parseLocalDate(override.effectiveTo)
+      if (isNaN(to.getTime())) return true
+      return d <= to
+    }
+
+    /**
+     * Effective config at a given date, computed by applying every
+     * override active on that date to a deep clone of the base.
+     *
+     * Resolution order:
+     *   1. Collect overrides active on this date.
+     *   2. Build per-target maps keyed by (dorm name / dorm+room name / bed id),
+     *      keeping only the most-recently-created override per (target, attr).
+     *   3. For each dormitory → room → bed, resolve:
+     *        - bed.active: explicit bed override > cascade from room > base
+     *        - room.active: explicit room override > cascade from dorm > base
+     *        - room.gender: explicit room gender override > base
+     *        - dorm.active: explicit dorm override > base
+     *   4. Bubble exceptions back up so iteration finds them:
+     *        - If any bed in a room is active (e.g. via bed-level exception
+     *          inside a closed room), the room is marked active.
+     *        - If any room in a dorm is active, the dorm is marked active.
+     *
+     * Pass `date === null` to skip override resolution and return the raw
+     * base tree (useful for editing the base config in Room Configuration).
+     */
+    const dormitoriesAt = computed(() => {
+      return (date: string | null): Dormitory[] => {
+        if (!date) return dormitories.value
+
+        const active = overrides.value.filter(o => isOverrideActiveOn(o, date))
+        if (active.length === 0) return dormitories.value
+
+        // Most-recently-created wins at same target+attr level.
+        const sorted = [...active].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+
+        const dormActive = new Map<string, boolean>()
+        const roomActive = new Map<string, boolean>()
+        const roomGender = new Map<string, RoomGender>()
+        const bedActive = new Map<string, boolean>()
+
+        const roomKey = (dormName: string, roomName: string) => `${dormName} ${roomName}`
+
+        for (const o of sorted) {
+          if (o.target.kind === 'dormitory' && o.change.attr === 'active') {
+            if (!dormActive.has(o.target.dormitoryName)) {
+              dormActive.set(o.target.dormitoryName, o.change.value)
+            }
+          } else if (o.target.kind === 'room' && o.change.attr === 'active') {
+            const key = roomKey(o.target.dormitoryName, o.target.roomName)
+            if (!roomActive.has(key)) roomActive.set(key, o.change.value)
+          } else if (o.target.kind === 'room' && o.change.attr === 'gender') {
+            const key = roomKey(o.target.dormitoryName, o.target.roomName)
+            if (!roomGender.has(key)) roomGender.set(key, o.change.value)
+          } else if (o.target.kind === 'bed' && o.change.attr === 'active') {
+            if (!bedActive.has(o.target.bedId)) {
+              bedActive.set(o.target.bedId, o.change.value)
+            }
+          }
+        }
+
+        // toRaw() unwraps Vue's reactive Proxy so structuredClone can walk the tree.
+        const cloned: Dormitory[] = structuredClone(toRaw(dormitories.value))
+
+        for (const dorm of cloned) {
+          const dormSelfActive = dormActive.has(dorm.dormitoryName)
+            ? dormActive.get(dorm.dormitoryName)!
+            : dorm.active
+
+          let anyRoomActive = false
+
+          for (const room of dorm.rooms) {
+            const rKey = roomKey(dorm.dormitoryName, room.roomName)
+
+            let roomSelfActive: boolean
+            if (roomActive.has(rKey)) {
+              roomSelfActive = roomActive.get(rKey)!
+            } else if (!dormSelfActive) {
+              roomSelfActive = false
+            } else {
+              roomSelfActive = room.active
+            }
+
+            if (roomGender.has(rKey)) {
+              room.roomGender = roomGender.get(rKey)!
+            }
+
+            let anyBedActive = false
+
+            for (const bed of room.beds) {
+              const baseBedActive = bed.active !== false
+              let bedFinalActive: boolean
+
+              if (bedActive.has(bed.bedId)) {
+                bedFinalActive = bedActive.get(bed.bedId)!
+              } else if (!roomSelfActive) {
+                bedFinalActive = false
+              } else {
+                bedFinalActive = baseBedActive
+              }
+
+              bed.active = bedFinalActive
+              if (bedFinalActive) anyBedActive = true
+            }
+
+            // Bed-level exception bubbles room active so iteration finds it.
+            if (anyBedActive) roomSelfActive = true
+            room.active = roomSelfActive
+            if (roomSelfActive) anyRoomActive = true
+          }
+
+          // Room-level exception bubbles dorm active.
+          dorm.active = anyRoomActive ? true : dormSelfActive
+        }
+
+        return cloned
+      }
+    })
+
+    /**
+     * True iff the bed exists, its room is active, and its dormitory is
+     * active for **every day** in the half-open stay window
+     * `[arrival, departure)`. Used by auto-placement and drop validation
+     * so a candidate can't be placed on a bed that closes mid-stay.
+     *
+     * Missing dates = "always present" = check at "now" (today).
+     */
+    function isBedActiveDuringStay(
+      bedId: string,
+      arrival: string | null | undefined,
+      departure: string | null | undefined
+    ): boolean {
+      // No overrides → fall through to base active state lookup.
+      if (overrides.value.length === 0) {
+        const bed = getBedById.value(bedId)
+        if (!bed || bed.active === false) return false
+        const room = getRoomByBedId.value(bedId)
+        if (!room || !room.active) return false
+        const dorm = getDormitoryByBedId.value(bedId)
+        if (!dorm || !dorm.active) return false
+        return true
+      }
+
+      // For half-open intervals, we need to check days [arrival, departure).
+      // Missing/invalid dates: check just today.
+      const start = arrival ? parseLocalDate(arrival) : new Date()
+      const end = departure ? parseLocalDate(departure) : new Date()
+      start.setHours(0, 0, 0, 0)
+      end.setHours(0, 0, 0, 0)
+
+      if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+        const today = new Date().toISOString().slice(0, 10)
+        return isBedActiveOn(bedId, today)
+      }
+
+      // Walk each day in the half-open window. For single-day stays
+      // (start === end), check that one day.
+      const cursor = new Date(start)
+      const stopDate = end > start ? end : new Date(start.getTime() + 86400000)
+      while (cursor < stopDate) {
+        const iso = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, '0')}-${String(cursor.getDate()).padStart(2, '0')}`
+        if (!isBedActiveOn(bedId, iso)) return false
+        cursor.setDate(cursor.getDate() + 1)
+      }
+      return true
+    }
+
+    /**
+     * True iff the bed (and its containing room + dorm) is active on the
+     * specified date, after applying overrides.
+     */
+    function isBedActiveOn(bedId: string, date: string): boolean {
+      const dorms = dormitoriesAt.value(date)
+      for (const dorm of dorms) {
+        if (!dorm.active) continue
+        for (const room of dorm.rooms) {
+          if (!room.active) continue
+          for (const bed of room.beds) {
+            if (bed.bedId === bedId) return bed.active !== false
+          }
+        }
+      }
+      return false
+    }
+
+    /**
+     * Effective room gender at a given date (after overrides). Returns
+     * the base gender if there's no active gender override on that day.
+     */
+    function roomGenderAt(dormitoryName: string, roomName: string, date: string): RoomGender | null {
+      const dorms = dormitoriesAt.value(date)
+      const dorm = dorms.find(d => d.dormitoryName === dormitoryName)
+      if (!dorm) return null
+      const room = dorm.rooms.find(r => r.roomName === roomName)
+      return room?.roomGender ?? null
+    }
+
+    // --- Override CRUD ---
+
+    /**
+     * Throws on a backwards date range (`effectiveTo < effectiveFrom`)
+     * since that would silently create a no-op override — typically a
+     * UI-side typo rather than a meaningful state. Validates only the
+     * direction; if either side is unparseable, lets it through (older
+     * data with unusual date formats may still need to round-trip).
+     */
+    function _validateOverrideRange(from: string, to: string | null): void {
+      if (to === null) return
+      const fromD = parseLocalDate(from)
+      const toD = parseLocalDate(to)
+      if (isNaN(fromD.getTime()) || isNaN(toD.getTime())) return
+      if (toD < fromD) {
+        throw new RangeError(
+          `Override has effectiveTo (${to}) before effectiveFrom (${from}).`
+        )
+      }
+    }
+
+    function addOverride(input: {
+      target: OverrideTarget
+      change: OverrideAttribute
+      effectiveFrom: string
+      effectiveTo: string | null
+      presetId?: string | null
+      applicationId?: string | null
+      note?: string
+    }): ConfigOverride {
+      _validateOverrideRange(input.effectiveFrom, input.effectiveTo)
+      const override: ConfigOverride = {
+        id: crypto.randomUUID(),
+        target: input.target,
+        change: input.change,
+        effectiveFrom: input.effectiveFrom,
+        effectiveTo: input.effectiveTo,
+        presetId: input.presetId ?? null,
+        applicationId: input.applicationId ?? null,
+        note: input.note,
+        createdAt: new Date().toISOString(),
+      }
+      overrides.value.push(override)
+      return override
+    }
+
+    function deleteOverride(overrideId: string): boolean {
+      const idx = overrides.value.findIndex(o => o.id === overrideId)
+      if (idx === -1) return false
+      overrides.value.splice(idx, 1)
+      return true
+    }
+
+    function updateOverride(overrideId: string, updates: Partial<Omit<ConfigOverride, 'id' | 'createdAt'>>): boolean {
+      const o = overrides.value.find(x => x.id === overrideId)
+      if (!o) return false
+      Object.assign(o, updates)
+      return true
+    }
+
+    // --- Preset CRUD ---
+
+    function addPreset(input: { name: string; description?: string; entries?: PresetTemplateEntry[] }): OverridePreset {
+      const now = new Date().toISOString()
+      const preset: OverridePreset = {
+        id: crypto.randomUUID(),
+        name: input.name,
+        description: input.description,
+        entries: input.entries ?? [],
+        createdAt: now,
+        updatedAt: now,
+      }
+      presets.value.push(preset)
+      return preset
+    }
+
+    function updatePreset(presetId: string, updates: Partial<Omit<OverridePreset, 'id' | 'createdAt'>>): boolean {
+      const p = presets.value.find(x => x.id === presetId)
+      if (!p) return false
+      Object.assign(p, updates)
+      p.updatedAt = new Date().toISOString()
+      return true
+    }
+
+    function deletePreset(presetId: string): boolean {
+      const idx = presets.value.findIndex(p => p.id === presetId)
+      if (idx === -1) return false
+      presets.value.splice(idx, 1)
+      // Also delete every override that came from this preset (any application).
+      overrides.value = overrides.value.filter(o => o.presetId !== presetId)
+      return true
+    }
+
+    /**
+     * Apply a preset for a given date window. Emits one override per
+     * template entry, all tagged with this preset's id and a fresh
+     * `applicationId` so the application can be reverted as a unit.
+     *
+     * Returns the `applicationId` (or null if the preset doesn't exist).
+     */
+    function applyPreset(
+      presetId: string,
+      effectiveFrom: string,
+      effectiveTo: string | null,
+      note?: string
+    ): string | null {
+      const preset = presets.value.find(p => p.id === presetId)
+      if (!preset) return null
+      _validateOverrideRange(effectiveFrom, effectiveTo)
+      const applicationId = crypto.randomUUID()
+      for (const entry of preset.entries) {
+        addOverride({
+          target: entry.target,
+          change: entry.change,
+          effectiveFrom,
+          effectiveTo,
+          presetId,
+          applicationId,
+          note,
+        })
+      }
+      return applicationId
+    }
+
+    /**
+     * Delete every override emitted by a specific preset application.
+     * Returns the number of overrides removed.
+     */
+    function revertPresetApplication(applicationId: string): number {
+      const before = overrides.value.length
+      overrides.value = overrides.value.filter(o => o.applicationId !== applicationId)
+      return before - overrides.value.length
+    }
+
     // Auto-save watcher: debounced save of dormitories to active layout
     let _autoSaveTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -600,12 +963,28 @@ export const useDormitoryStore = defineStore(
       switchLayout,
       deleteLayout,
       importLayouts,
+
+      // Time-based overrides + presets
+      overrides,
+      presets,
+      dormitoriesAt,
+      isBedActiveDuringStay,
+      isBedActiveOn,
+      roomGenderAt,
+      addOverride,
+      deleteOverride,
+      updateOverride,
+      addPreset,
+      updatePreset,
+      deletePreset,
+      applyPreset,
+      revertPresetApplication,
     }
   },
   {
     persist: {
       key: 'dormAssignments-dormitories',
-      paths: ['dormitories', 'configName', 'layouts', 'activeLayoutId', 'bedShapeVersion'],
+      paths: ['dormitories', 'configName', 'layouts', 'activeLayoutId', 'bedShapeVersion', 'overrides', 'presets'],
     },
   }
 )

--- a/src/types/Overrides.ts
+++ b/src/types/Overrides.ts
@@ -1,0 +1,106 @@
+/**
+ * Time-based room configuration overrides.
+ *
+ * The dormitory tree (`dormitories: Dormitory[]`) holds the **base**
+ * config. Overrides are dated events that change one attribute on one
+ * target for a `[effectiveFrom, effectiveTo]` window (inclusive on both
+ * ends; effectiveTo = null means open-ended).
+ *
+ * Effective config at a date D is computed as:
+ *   base + reduce(overrides effective on D)
+ *
+ * Cascade resolution: dormitory-level overrides cascade to their rooms
+ * and beds; a same-window child override (room or bed) wins over the
+ * cascade. Within a single level, most-recently-created wins.
+ *
+ * Presets are NAMED BUNDLES of (target, change) templates. Applying a
+ * preset emits one `ConfigOverride` per template entry, all tagged with
+ * the preset's id. Reverting a preset application deletes every override
+ * with that `presetId` inside the applied window. Presets don't store a
+ * snapshot — they're a template that produces overrides on demand, so
+ * applying the same preset twice for different dates yields independent
+ * applications that can be edited/reverted independently.
+ *
+ * See `specs/TimeBasedRoomConfig.md` for the full design.
+ */
+
+import type { RoomGender } from './Room'
+
+/**
+ * What an override targets.
+ *
+ * - Dormitories are identified by name (unique across the tree).
+ * - Rooms are identified by (dormitoryName, roomName) because room
+ *   names are only unique within a dormitory.
+ * - Beds are identified by `bedId` (globally unique).
+ *
+ * Using names rather than indices keeps overrides stable across
+ * reorderings, base-config edits, and JSON round-trips.
+ */
+export type OverrideTarget =
+  | { kind: 'dormitory'; dormitoryName: string }
+  | { kind: 'room'; dormitoryName: string; roomName: string }
+  | { kind: 'bed'; bedId: string }
+
+/**
+ * What attribute the override changes. `active` applies to all three
+ * target kinds; `gender` applies only to room targets (validated at
+ * apply-time, not in the type).
+ */
+export type OverrideAttribute =
+  | { attr: 'active'; value: boolean }
+  | { attr: 'gender'; value: RoomGender }
+
+export interface ConfigOverride {
+  id: string
+  target: OverrideTarget
+  change: OverrideAttribute
+  /**
+   * Inclusive start date (ISO YYYY-MM-DD).
+   */
+  effectiveFrom: string
+  /**
+   * Inclusive end date (ISO YYYY-MM-DD), or null for open-ended.
+   */
+  effectiveTo: string | null
+  /**
+   * If set, this override was emitted by applying a preset; revert
+   * deletes every override sharing this `presetId` within the applied
+   * window. null = one-off override created by the operator directly.
+   */
+  presetId: string | null
+  /**
+   * Identifies the specific application of a preset. Multiple applications
+   * of the same preset to different date windows share `presetId` but have
+   * distinct `applicationId`s. null for one-off overrides.
+   */
+  applicationId: string | null
+  /**
+   * Optional operator-entered reason ("heater broken", "Women's retreat").
+   */
+  note?: string
+  createdAt: string
+}
+
+/**
+ * One entry in a preset template: which target + which attribute.
+ * No date — dates come from the preset application.
+ */
+export interface PresetTemplateEntry {
+  target: OverrideTarget
+  change: OverrideAttribute
+}
+
+export interface OverridePreset {
+  id: string
+  name: string
+  description?: string
+  /**
+   * The template entries this preset emits on apply. Editing the
+   * preset edits these entries in place; previously-emitted overrides
+   * are not retroactively updated (preserves audit history).
+   */
+  entries: PresetTemplateEntry[]
+  createdAt: string
+  updatedAt: string
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,15 @@ export { DEFAULT_SETTINGS, GROUP_TYPE_LABELS, DEFAULT_GROUP_PLACEMENT_ORDER, DEF
 // Room Layout types
 export type { RoomLayout } from './RoomLayout'
 
+// Time-based override types
+export type {
+  ConfigOverride,
+  OverridePreset,
+  OverrideTarget,
+  OverrideAttribute,
+  PresetTemplateEntry,
+} from './Overrides'
+
 // Storage types
 export type { StorageData, LegacyStorageData } from './Storage'
 


### PR DESCRIPTION
## Summary
First of three PRs implementing time-based room configuration per [specs/TimeBasedRoomConfig.md](./specs/TimeBasedRoomConfig.md). Data layer only — no UI changes yet.

- New `ConfigOverride` + `OverridePreset` types with cascading resolution (dorm → room → bed; same-window child override wins; most-recent-at-same-level wins).
- `dormitoryStore.dormitoriesAt(date)` returns the effective tree after applying overrides.
- `isBedActiveDuringStay(bedId, arrival, departure)` walks the half-open stay window — auto-placement + drop validation will call this in PR 2.
- Presets are templates (not snapshots): `applyPreset` emits one override per template entry tagged with a fresh `applicationId`, so the same preset applied to two date windows reverts independently.
- Persists `overrides` and `presets` alongside the existing `dormAssignments-dormitories` key.

## Why three PRs
- **#1 (this)** — data layer + tests, reviewable in isolation.
- **#2** — read-side UI: Table View renders effective config (hatched inactive rooms/beds, gender-override badge), and `useAutoPlacement` / `useDropValidation` integrate `isBedActiveDuringStay`.
- **#3** — write-side UI: Presets list, Overrides timeline, apply/revert flow with conflict dialog, right-click "Add override" from Table View.

## Test plan
- [x] 16 new tests cover cascade behavior, exception wins, gender override windows, half-open stay semantics, open-ended overrides, and preset apply/revert lifecycle.
- [x] Full suite passes (111/111).
- [x] `npm run build` clean (vue-tsc + vite).
- [ ] Sanity check on Netlify deploy preview — no UI changes so this is mostly a no-op visual check.
- [ ] Localstorage existing-data smoke test: load a session that has dormitories, layouts, assignments; nothing should break since the persist key just gains two new paths.

## Open questions (carried from spec)
1. On revert, should orphaned same-window child overrides auto-delete?
2. Want a one-click "auto-place affected guests" after override breaks assignments?
3. Print views during override windows: omit closed rooms entirely, or list as "(closed)"?
4. Overrides in CSV export, or JSON-only?

🤖 Generated with [Claude Code](https://claude.com/claude-code)