### PR TITLE
Time-based room overrides: read-side UI (PR 2/3)

### DIFF
--- a/docs/plans/2026-06-13-encrypted-cloud-sync-design.md
+++ b/docs/plans/2026-06-13-encrypted-cloud-sync-design.md
@@ -1,0 +1,238 @@
+# Encrypted Cloud Sync — Design
+
+**Date:** 2026-06-13
+**Status:** Design approved in brainstorming; not yet implemented
+**Priorities (from the user, in order):** 1. Security 2. Long-term stability / fallback to localStorage
+
+---
+
+## 1. Purpose & Problem
+
+Today the app is fully client-side: all state lives in `localStorage` via
+`pinia-plugin-persistedstate`. That means data is trapped on one browser on one
+device. We want an **optional** online sync layer so that:
+
+- A single operator can use the tool across multiple devices, **and**
+- Two operators can share one retreat's data (they almost never edit
+  simultaneously).
+
+Sync must be **purely additive**: if it's disabled, unreachable, or broken, the
+app behaves exactly as it does today. localStorage remains the source of truth.
+
+## 2. Success Criteria
+
+- Data round-trips between two devices through the server, encrypted end-to-end.
+- The server (and any backup of it) only ever holds **ciphertext** — a leak of
+  the database or its backups reveals nothing without the password.
+- With sync off or the network down, the app is **functionally identical** to
+  today (no errors, no blocking, no data loss).
+- The two operators effectively never lose each other's work; the rare overlap
+  is surfaced, not silently clobbered.
+- The server is something agents can stand up and keep running for years with
+  near-zero maintenance.
+
+## 3. Decisions (locked during brainstorming)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Use case | One operator multi-device **and** two operators sharing — but **almost never simultaneous** editing |
+| 2 | Conflict model | **Last-write-wins + revision guard** ("seatbelt"). No CRDT, no real-time server. |
+| 3 | Storage backend | **Self-hosted VPS** (on `exe.dev`) with **SQLite** (single file, easy to back up) |
+| 4 | Backup of the SQLite file | **TBD** — litestream / cron `git push` / `rsync`. Untrusted target is fine (ciphertext only). |
+| 5 | Sync trigger | **Auto-save feel**: debounced auto-push + auto-pull on load/focus. No save button in the happy path. |
+| 6 | Encryption | **End-to-end** in the browser via WebCrypto. Server never sees password or plaintext. |
+| 7 | Server access control | **Password gates everything** — one password derives both the encryption key and a server auth proof. No separate tokens, no user accounts. |
+| 8 | Password across sessions | **Remember on device, opt-in** (checkbox to not remember). Local data is already plaintext on the device, so this is low marginal risk. |
+| 9 | Shared secret | Both operators **share one password**. Accepted. |
+| 10 | Lost password | **No cloud recovery** (true E2E). localStorage still has everything; re-key and re-push. Accepted. |
+| 11 | Workspace identity | The **password *is* the workspace.** One password → one encrypted blob. A different password = a separate space, for free. |
+| 12 | Server runtime | **Go, single static binary** (`modernc.org/sqlite`, pure Go, no CGO) behind **Caddy** (automatic HTTPS). Chosen for longevity / minimal upkeep since agents maintain it. |
+
+## 4. Security Architecture
+
+### 4.1 Threat model & honest scope
+- **Protected:** the cloud copy, data in transit (TLS), and all server-side
+  backups. A full compromise of the VPS or its backups yields only ciphertext
+  plus a non-secret salt.
+- **Not protected (and already true today):** data at rest in `localStorage` on
+  an unlocked device. Anyone with the unlocked laptop already sees everything.
+  The sync password's job is the cloud/transit/backup surface, not the local
+  device.
+
+### 4.2 Key derivation (all WebCrypto, zero new browser deps)
+1. Random **16-byte salt** generated once per workspace, stored alongside the
+   blob on the server (salt is non-secret).
+2. `PBKDF2-HMAC-SHA256`, **600,000 iterations** (OWASP 2023 floor), over the
+   password + salt → 64 bytes of key material.
+3. Split the 64 bytes:
+   - bytes `[0..32)` → **encKey** (AES-256-GCM). **Never leaves the browser.**
+   - bytes `[32..64)` → **authProof** (256-bit). Sent to the server to prove
+     "I know the password."
+4. **Workspace id = `SHA-256(authProof)`** (hex). The server stores rows keyed
+   by this id and stores only `SHA-256(authProof)` — never authProof itself.
+   So the proof simultaneously **identifies** the workspace and **authorizes**
+   read/write.
+
+> Note: because salt + the stored proof-hash are server-side, a server/backup
+> leak technically enables an *offline brute-force of the password*. This is the
+> same exposure as the encrypted blob itself (also offline-attackable with the
+> salt), so it adds no new weakness. Mitigation = a strong shared passphrase +
+> the 600k-iteration KDF. (Argon2id is a future upgrade; see §9.)
+
+### 4.3 Encryption of the blob
+- Cipher: **AES-256-GCM**.
+- Fresh random **96-bit IV per push**, prepended to the ciphertext.
+- GCM auth tag covers integrity — tampering is detected on decrypt.
+
+## 5. Sync Protocol (last-write-wins + revision guard)
+
+Server row (one per workspace):
+
+```
+workspaces(
+  id          TEXT PRIMARY KEY,   -- SHA-256(authProof), hex
+  proof_hash  BLOB NOT NULL,      -- SHA-256(authProof) (same value, explicit)
+  revision    INTEGER NOT NULL,   -- monotonic, server-incremented
+  salt        BLOB NOT NULL,      -- 16 bytes, non-secret
+  iv          BLOB NOT NULL,      -- 12 bytes
+  ciphertext  BLOB NOT NULL,      -- AES-256-GCM output
+  updated_at  TEXT NOT NULL,      -- ISO timestamp, plaintext (non-sensitive)
+  created_at  TEXT NOT NULL
+)
+```
+
+`lastWriter` (operator name) lives **inside** the encrypted blob, so the
+conflict banner reads it only after a successful decrypt. `updated_at` and
+`revision` are plaintext metadata (non-sensitive) used for the guard.
+
+### Endpoints (HTTPS only, via Caddy)
+- `POST /v1/pull` — `Authorization: Bearer <authProofHex>`
+  → `200 {revision, salt, iv, ciphertext}` or `404` (workspace doesn't exist
+  yet). Server verifies `SHA-256(proof) == stored hash`.
+- `POST /v1/push` — `Authorization: Bearer <authProofHex>`,
+  body `{baseRevision, salt, iv, ciphertext}`
+  → `200 {revision}` if `baseRevision == current revision` (then increment &
+  store); → `409 {currentRevision}` if stale (the **seatbelt**). First-ever push
+  uses `baseRevision: 0`.
+
+### Client flow
+- **Pull** on app load, on window focus, and on a light poll (~20–30 s) while
+  open. If the pulled revision is newer than what we last applied → reconcile.
+- **Push** debounced ~3–5 s after the last local change (detected via a hash of
+  the snapshot, so identical state doesn't churn the server).
+- **409 on push** → show a non-blocking banner: *"Someone saved changes N min
+  ago — Reload theirs / Keep mine (overwrite)."* This is the only place the user
+  ever confronts the conflict, and it never auto-destroys work.
+
+## 6. What gets synced
+
+A single JSON **snapshot** (one blob, matching the last-write-wins model)
+containing a manifest of all persisted state:
+
+- Pinia persisted store keys: `guestStore`, `dormitoryStore`,
+  `assignmentStore`, `settingsStore`, `timelineStore`.
+- The standalone `dormAssignments-*` localStorage keys (view date, print mode,
+  per-sub-tab column prefs, print date range, etc.).
+- A top-level `schemaVersion` for forward-compatible migrations.
+
+The exact key manifest is enumerated at implementation time from
+`main.ts` / each store's `persist` config so nothing is silently dropped.
+
+## 7. Fallback & Stability (priority #2)
+
+- Every network call is wrapped so **any failure is non-fatal**: timeouts,
+  offline, 5xx, TLS errors → app keeps using localStorage, status indicator
+  shows "offline / not synced," retry with backoff.
+- Sync is **opt-in** and **off by default**. Existing users are unaffected until
+  they enter a server URL + password.
+- A small **sync status indicator** (synced / syncing / offline / conflict) so
+  the operator always knows the truth.
+- Decrypt failure (wrong password, corrupt blob) is surfaced clearly and
+  **never** overwrites good local data.
+
+## 8. Client Integration (Vue/Pinia)
+
+- New `src/features/sync/`:
+  - `useSync.ts` composable — orchestrates pull/push/debounce/poll/conflict.
+  - `crypto.ts` — WebCrypto KDF + AES-GCM helpers (pure, unit-testable).
+  - `SyncStatusIndicator.vue` — header status chip.
+  - `SyncConflictBanner.vue` — the 409 reconcile UI.
+- New `syncStore` (Pinia) — config (server URL, remember-me, operator name) and
+  runtime status. Config persists; the derived key is cached only if
+  "remember on device" is on.
+- Settings panel gains a **Cloud Sync** section: enable toggle, server URL,
+  password field, "remember on this device" checkbox, operator name, and a
+  manual "Sync now" / "Pull now" escape hatch.
+
+## 9. Out of Scope (YAGNI)
+
+- Real-time collaborative editing / CRDT / OT / live cursors.
+- Per-user accounts, roles, or any login system beyond the shared password.
+- Multi-tenant hosting (one monastery, workspaces are just passwords).
+- Password recovery / reset (impossible by E2E design — accepted).
+- Per-field or per-store partial sync (one snapshot blob is enough).
+
+### Possible future upgrades (noted, not built)
+- **Argon2id** KDF (via a small wasm lib) to harden against offline brute force.
+- Server-side **revision history** (keep last N blobs) for "undo a bad push."
+- Compression of the blob before encryption for large datasets.
+
+## 10. Server Deployment (exe.dev)
+
+- Go binary built with `modernc.org/sqlite` (pure Go → static, no CGO).
+- `systemd` unit keeps it running; data dir holds `sync.db`.
+- **Caddy** reverse proxy on a subdomain (e.g. `sync.<domain>`) for automatic
+  HTTPS + cert renewal.
+- Hardening: request body size cap (e.g. 5 MB), basic per-IP rate limit,
+  constant-time proof comparison.
+- Backup of `sync.db`: **TBD** (litestream / cron `git push` / `rsync`) — target
+  need not be trusted since the blob is ciphertext.
+
+## 11. Considered & Rejected: CRDTs (Yjs / Automerge / Gun.db)
+
+We scanned CRDT-based real-time approaches and rejected them for this app.
+
+**What a CRDT actually buys:** exactly one thing this design lacks — automatic
+merging of *concurrent* edits with no conflict prompt (two people editing the
+same retreat in the same minute, fusing field-by-field). Offline edits,
+persistence, and multi-device sync we already get more simply. Since
+simultaneous editing **almost never happens** here (decision #1), the one thing
+CRDTs are for is the thing we don't need.
+
+**Fights priority #1 (security):** CRDT sync protocols assume the server can read
+and merge updates. Keeping true end-to-end encryption means encrypting every
+update opaquely and merging only on clients — a known-hard, DIY area the Yjs
+community has wrestled with for years. Our blob-level `PBKDF2 → AES-GCM` is
+boring, standard, and auditable; the correct posture for guest PII.
+
+**Fights priority #2 (stability):**
+- *Unbounded growth* — CRDTs retain merge metadata, tombstones, and often full
+  edit history forever (Yjs version-vector + delete-set per version; Automerge a
+  DAG node per keystroke). Our snapshot stays the size of the data.
+- *More moving parts* — WASM bundles, harder debugging, a CRDT-aware relay vs.
+  two dumb endpoints over SQLite.
+- *Store rewrite* — our state is normalized Pinia records, not a text document.
+  CRDT merge would require re-modeling every field as a registered CRDT type.
+
+**The specific libraries:**
+- **Yjs** — best-in-class, but built for collaborative *text/rich-text editing*
+  (shared cursors in a document). Wrong data shape for structured records.
+- **Gun.db** — has E2E built in (SEA: ECDH + AES-GCM), but it's an opinionated
+  P2P **graph database** with accumulated technical debt. Replaces "one SQLite
+  file I can back up" with a network that's hard to reason about and keep boring
+  for years. Directly opposed to priority #2.
+
+**The one trigger to revisit:** if real usage shows *frequent* simultaneous
+editing and the conflict banner becomes annoying. The response then would be
+**Yjs + a relay (e.g. y-sweet)** accepting the E2E complexity, or a lighter
+middle step — **per-record last-write-wins** (merge by record timestamp on pull)
+instead of whole-blob, which removes most clobbering without any CRDT machinery.
+**Not** Gun.db.
+
+## 12. Open Implementation Questions (resolve at build time)
+
+1. Exact subdomain/URL on `exe.dev` and Caddy config.
+2. Final backup mechanism for `sync.db` (§10).
+3. Precise localStorage key manifest (§6) — enumerate from current persist
+   configs.
+4. Debounce/poll timings — start at 3–5 s push / 20–30 s poll, tune later.

--- a/src/features/assignments/composables/useAutoPlacement.overrides.test.ts
+++ b/src/features/assignments/composables/useAutoPlacement.overrides.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Override-aware availability tests for auto-placement.
+ *
+ * `isBedAvailableForGuest` / `isBedAvailableForGroup` must reject a
+ * bed when a time-based override leaves it inactive during the
+ * candidate's stay window — even when the base config has the bed
+ * active and no other guest is assigned to it.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAutoPlacement } from './useAutoPlacement'
+import { useGuestStore } from '@/stores/guestStore'
+import { useDormitoryStore } from '@/stores/dormitoryStore'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+    key: () => null,
+    length: 0,
+  }
+})()
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+if (typeof globalThis.crypto === 'undefined') {
+  ;(globalThis as { crypto: Crypto }).crypto = {
+    randomUUID: () => Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`,
+  } as Crypto
+} else if (typeof globalThis.crypto.randomUUID !== 'function') {
+  globalThis.crypto.randomUUID = () =>
+    Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`
+}
+
+function seedSingleBed(bedId = 'B01') {
+  const dorm = useDormitoryStore()
+  dorm.importDormitories([
+    {
+      dormitoryName: 'Test Dorm',
+      active: true,
+      rooms: [
+        {
+          roomName: 'Test Room',
+          roomGender: 'M',
+          active: true,
+          beds: [{ bedId, bedType: 'single', position: 1, assignments: [] }],
+        },
+      ],
+    },
+  ])
+  return bedId
+}
+
+describe('auto-placement — override-aware availability', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('skips a bed closed by override during the candidate\'s stay', () => {
+    const bedId = seedSingleBed()
+    const dorm = useDormitoryStore()
+    dorm.addOverride({
+      target: { kind: 'bed', bedId },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-01',
+      effectiveTo: '2026-07-31',
+    })
+    const guest = useGuestStore().addGuest({
+      firstName: 'Alice',
+      lastName: 'T',
+      gender: 'M',
+      age: 30,
+      arrival: '2026-07-10',
+      departure: '2026-07-15',
+      indivGrp: 'individual',
+    })
+
+    const { autoPlaceGuests } = useAutoPlacement()
+    const result = autoPlaceGuests()
+    expect(result.suggestions.has(guest.id)).toBe(false)
+  })
+
+  it('places the same guest when their stay falls outside the override window', () => {
+    const bedId = seedSingleBed()
+    const dorm = useDormitoryStore()
+    dorm.addOverride({
+      target: { kind: 'bed', bedId },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-01',
+      effectiveTo: '2026-07-31',
+    })
+    const guest = useGuestStore().addGuest({
+      firstName: 'Bob',
+      lastName: 'T',
+      gender: 'M',
+      age: 30,
+      arrival: '2026-08-05',
+      departure: '2026-08-10',
+      indivGrp: 'individual',
+    })
+
+    const { autoPlaceGuests } = useAutoPlacement()
+    const result = autoPlaceGuests()
+    expect(result.suggestions.get(guest.id)).toBe(bedId)
+  })
+
+  it('respects a dormitory-level close cascading down to the bed', () => {
+    const bedId = seedSingleBed()
+    const dorm = useDormitoryStore()
+    dorm.addOverride({
+      target: { kind: 'dormitory', dormitoryName: 'Test Dorm' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-04',
+      effectiveTo: '2026-07-11',
+    })
+    const guest = useGuestStore().addGuest({
+      firstName: 'Carlos',
+      lastName: 'T',
+      gender: 'M',
+      age: 30,
+      arrival: '2026-07-06',
+      departure: '2026-07-09',
+      indivGrp: 'individual',
+    })
+
+    const { autoPlaceGuests } = useAutoPlacement()
+    const result = autoPlaceGuests()
+    expect(result.suggestions.has(guest.id)).toBe(false)
+  })
+})

--- a/src/features/assignments/composables/useAutoPlacement.ts
+++ b/src/features/assignments/composables/useAutoPlacement.ts
@@ -52,12 +52,15 @@ export function useAutoPlacement() {
   }
 
   /**
-   * A bed is "available for guest" iff it's active AND none of its existing
-   * assignments overlap with the candidate guest's stay. Date-aware
-   * replacement for the old `!bed.assignedGuestId` check.
+   * A bed is "available for guest" iff it's active for the guest's entire
+   * stay (including any time-based overrides) AND none of its existing
+   * assignments overlap with the candidate guest's stay.
    */
   function isBedAvailableForGuest(bed: Bed, guest: Guest): boolean {
     if (bed.active === false) return false
+    if (!dormitoryStore.isBedActiveDuringStay(bed.bedId, guest.arrival, guest.departure)) {
+      return false
+    }
     for (const a of bed.assignments) {
       if (a.guestId === guest.id) continue
       const other = guestStore.guests.find(g => g.id === a.guestId)
@@ -68,12 +71,18 @@ export function useAutoPlacement() {
   }
 
   /**
-   * A bed is "available for group" iff it's active AND none of its existing
-   * assignments overlap with ANY member of the group. Conservative — a bed
-   * that overlaps even one member is excluded for the whole group.
+   * A bed is "available for group" iff it's active for every member's stay
+   * (including overrides) AND none of its existing assignments overlap with
+   * ANY member of the group. Conservative — a bed that's inactive during
+   * even one member's stay is excluded for the whole group.
    */
   function isBedAvailableForGroup(bed: Bed, group: ClassifiedGroup): boolean {
     if (bed.active === false) return false
+    for (const member of group.members) {
+      if (!dormitoryStore.isBedActiveDuringStay(bed.bedId, member.arrival, member.departure)) {
+        return false
+      }
+    }
     for (const a of bed.assignments) {
       const other = guestStore.guests.find(g => g.id === a.guestId)
       if (!other) continue

--- a/src/features/dormitories/components/RoomCard.vue
+++ b/src/features/dormitories/components/RoomCard.vue
@@ -5,6 +5,7 @@
         <h4>{{ room.roomName }}</h4>
         <span :class="['badge', `badge-gender-${room.roomGender.toLowerCase()}`]">
           {{ room.roomGender }}
+          <span v-if="genderOverridden" class="override-marker" title="Room gender is set by a time-based override on this date">📅</span>
         </span>
       </div>
       <div class="room-actions">
@@ -52,11 +53,15 @@ interface Props {
   /** Color of the parent dormitory — rendered as a thin left stripe so
    *  the operator can still tell dorms apart in the flattened view. */
   dormColor?: string
+  /** True if this room's gender is currently set by a time-based override
+   *  rather than the base config — surfaces a small 📅 marker on the badge. */
+  genderOverridden?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   viewDate: null,
   dormColor: '#e5e7eb',
+  genderOverridden: false,
 })
 
 const guestStore = useGuestStore()
@@ -171,11 +176,19 @@ function handleAcceptRoomSuggestions() {
 }
 
 .badge {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
   padding: 2px 8px;
   border-radius: 10px;
   font-size: 0.7rem;
   font-weight: 500;
+
+  .override-marker {
+    font-size: 0.7rem;
+    line-height: 1;
+    cursor: help;
+  }
 
   &.badge-gender-m {
     background-color: #dbeafe;

--- a/src/features/dormitories/components/RoomList.vue
+++ b/src/features/dormitories/components/RoomList.vue
@@ -6,6 +6,9 @@
     </div>
 
     <div v-else ref="containerRef" class="rooms-container">
+      <div v-if="hasOverridesOnViewDate" class="override-banner" title="One or more configuration overrides are active on this date. Edit them in the Room Configuration tab.">
+        <span class="override-badge">📅</span> Overrides active on {{ viewDateLabel }} — layout differs from base config.
+      </div>
       <RoomGroupLinesOverlay v-if="isMounted && containerRef" :containerRef="containerRef" />
       <RoomCard
         v-for="entry in flatRooms"
@@ -13,6 +16,7 @@
         :room="entry.room"
         :view-date="viewDate"
         :dorm-color="entry.dormColor"
+        :gender-overridden="entry.genderOverridden"
       />
     </div>
   </div>
@@ -47,7 +51,56 @@ const dormitoryStore = useDormitoryStore()
 const guestStore = useGuestStore()
 const assignmentStore = useAssignmentStore()
 
-const dormitories = computed(() => dormitoryStore.dormitories)
+/**
+ * Convert the View Date prop into a YYYY-MM-DD string in local time so
+ * `dormitoriesAt` can resolve overrides. Null/undefined → null (raw base
+ * tree, no override resolution).
+ */
+function viewDateISO(d: Date | null | undefined): string | null {
+  if (!d) return null
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+const dormitories = computed(() => dormitoryStore.dormitoriesAt(viewDateISO(props.viewDate)))
+
+/**
+ * Rooms whose effective gender differs from base on the View Date —
+ * surfaced as a small 📅 badge so the operator knows the label is
+ * driven by an override, not a base-config edit.
+ */
+const genderOverriddenKeys = computed(() => {
+  const out = new Set<string>()
+  const date = viewDateISO(props.viewDate)
+  if (!date) return out
+  for (const dorm of dormitoryStore.dormitories) {
+    for (const room of dorm.rooms) {
+      const effective = dormitoryStore.roomGenderAt(dorm.dormitoryName, room.roomName, date)
+      if (effective && effective !== room.roomGender) {
+        out.add(`${dorm.dormitoryName}::${room.roomName}`)
+      }
+    }
+  }
+  return out
+})
+
+const hasOverridesOnViewDate = computed(() => {
+  const date = viewDateISO(props.viewDate)
+  if (!date) return false
+  // Cheap predicate: any override whose window covers viewDate.
+  return dormitoryStore.overrides.some(o => {
+    if (o.effectiveFrom > date) return false
+    if (o.effectiveTo === null) return true
+    return o.effectiveTo >= date
+  })
+})
+
+const viewDateLabel = computed(() => {
+  if (!props.viewDate) return ''
+  return props.viewDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+})
 
 function normalizeText(text: string): string {
   return text.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')
@@ -57,6 +110,7 @@ interface FlatRoomEntry {
   room: Room
   dormName: string
   dormColor: string
+  genderOverridden: boolean
 }
 
 /**
@@ -96,7 +150,13 @@ const flatRooms = computed<FlatRoomEntry[]>(() => {
         if (!matchesName && !matchesGuest) continue
       }
 
-      out.push({ room, dormName: dorm.dormitoryName, dormColor })
+      const key = `${dorm.dormitoryName}::${room.roomName}`
+      out.push({
+        room,
+        dormName: dorm.dormitoryName,
+        dormColor,
+        genderOverridden: genderOverriddenKeys.value.has(key),
+      })
     }
   }
   return out
@@ -138,5 +198,23 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.override-banner {
+  padding: 6px 12px;
+  margin-bottom: 4px;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  color: #92400e;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: help;
+}
+
+.override-badge {
+  font-size: 0.85rem;
 }
 </style>

--- a/src/shared/composables/useDropValidation.test.ts
+++ b/src/shared/composables/useDropValidation.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Drop validation must reject a drop when the bed is closed by a
+ * time-based override during the guest's stay, even if all other
+ * checks (gender, bunk) pass.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useDropValidation } from './useDropValidation'
+import { useGuestStore } from '@/stores/guestStore'
+import { useDormitoryStore } from '@/stores/dormitoryStore'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+    key: () => null,
+    length: 0,
+  }
+})()
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+if (typeof globalThis.crypto === 'undefined') {
+  ;(globalThis as { crypto: Crypto }).crypto = {
+    randomUUID: () => Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`,
+  } as Crypto
+} else if (typeof globalThis.crypto.randomUUID !== 'function') {
+  globalThis.crypto.randomUUID = () =>
+    Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`
+}
+
+function seed() {
+  const dorm = useDormitoryStore()
+  dorm.importDormitories([
+    {
+      dormitoryName: 'Test Dorm',
+      active: true,
+      rooms: [
+        {
+          roomName: 'Test Room',
+          roomGender: 'M',
+          active: true,
+          beds: [{ bedId: 'B01', bedType: 'single', position: 1, assignments: [] }],
+        },
+      ],
+    },
+  ])
+  const guest = useGuestStore().addGuest({
+    firstName: 'Alice',
+    lastName: 'T',
+    gender: 'M',
+    age: 30,
+    arrival: '2026-07-10',
+    departure: '2026-07-15',
+    indivGrp: 'individual',
+  })
+  return { guest, dorm }
+}
+
+describe('useDropValidation — override-aware', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('rejects a drop on a bed closed by override during the stay', () => {
+    const { guest, dorm } = seed()
+    dorm.addOverride({
+      target: { kind: 'bed', bedId: 'B01' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-01',
+      effectiveTo: '2026-07-31',
+    })
+    const { validateDrop } = useDropValidation()
+    const result = validateDrop(guest.id, 'B01')
+    expect(result.isValid).toBe(false)
+    expect(result.reason).toMatch(/inactive|override/i)
+  })
+
+  it('accepts a drop when the stay falls outside the override window', () => {
+    const { guest, dorm } = seed()
+    dorm.addOverride({
+      target: { kind: 'bed', bedId: 'B01' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-08-01',
+      effectiveTo: '2026-08-31',
+    })
+    const { validateDrop } = useDropValidation()
+    expect(validateDrop(guest.id, 'B01').isValid).toBe(true)
+  })
+
+  it('rejects a drop on a bed inside a dormitory closed by override', () => {
+    const { guest, dorm } = seed()
+    dorm.addOverride({
+      target: { kind: 'dormitory', dormitoryName: 'Test Dorm' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-04',
+      effectiveTo: '2026-07-11',
+    })
+    const { validateDrop } = useDropValidation()
+    const result = validateDrop(guest.id, 'B01')
+    expect(result.isValid).toBe(false)
+  })
+})

--- a/src/shared/composables/useDropValidation.ts
+++ b/src/shared/composables/useDropValidation.ts
@@ -31,6 +31,12 @@ export function useDropValidation() {
       return { isValid: false, reason: 'Room not found' }
     }
 
+    // Bed must be active during the guest's entire stay — covers
+    // time-based overrides (dorm closed, room closed, bed closed).
+    if (!dormitoryStore.isBedActiveDuringStay(bedId, guest.arrival, guest.departure)) {
+      return { isValid: false, reason: 'Bed inactive during stay (override active)' }
+    }
+
     return validateGuestBedCompatibility(guest, bed, room)
   }
 


### PR DESCRIPTION
## Summary
Wires the data layer from #40 into the read paths so overrides actually affect the UI and auto-placement / drag-drop behavior. No new way to create overrides yet — that's PR 3/3.

- **Auto-placement** (`useAutoPlacement.isBedAvailableForGuest` / `isBedAvailableForGroup`) skips a bed when an override leaves it inactive across the candidate's stay.
- **Drop validation** (`useDropValidation.validateDrop`) rejects drops onto override-closed beds with reason `"Bed inactive during stay (override active)"`.
- **Table View** (`RoomList.vue`) reads `dormitoriesAt(viewDate)` instead of the raw base tree — closed rooms/beds vanish from view on dates inside their inactive window.
- **Discoverability banner** — small amber bar above the room list when any override is active on the current View Date, so operators don't think the layout silently shrank.
- **Gender override marker** — 📅 next to a room's gender badge when the displayed gender comes from an override, not the base config.

## Deferred to PR 3/3
- Timeline view per-day hatching for inactive windows — the timeline spans many days, so this is a per-cell render change that pairs naturally with the override-editor UI.
- `overrideConflict` validation category — surfaces on existing guests whose assignment falls inside a newly-applied override window. Lives in the apply-preset flow which is PR 3's surface area.
- Timeline drag-drop currently bypasses `validateDrop` (consistent with existing pattern — it relies on non-blocking validation warnings); the `overrideConflict` category will cover this case in PR 3.

## Test plan
- [x] 6 new tests cover bed/dorm-level override rejection in both auto-placement and drop validation, plus the "stay falls outside the window" passthrough case.
- [x] Full suite passes (119/119).
- [x] `npm run build` clean (vue-tsc + vite).
- [ ] Manual smoke on Netlify deploy preview: load a session, switch View Date, confirm rooms disappear and reappear as expected.
- [ ] Without overrides: no UI change vs. main — banner hidden, no badges, behavior identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)