### PR TITLE
Time-based room overrides: write-side UI (PR 3/3)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -236,6 +236,7 @@
           empty-title="No rooms configured"
           empty-message="Add a dormitory to begin configuring rooms and beds."
         />
+        <PresetsAndOverridesSection />
       </div>
     </div>
 
@@ -297,7 +298,7 @@ import { HintBanner } from '@/features/hints/components'
 import { useHints } from '@/features/hints/composables/useHints'
 import { useTour } from '@/features/hints/composables/useTour'
 import { GuestList, GuestSearch, ColumnsDropdown } from '@/features/guests/components'
-import { RoomList, ConfigRoomList, LayoutSelector } from '@/features/dormitories/components'
+import { RoomList, ConfigRoomList, LayoutSelector, PresetsAndOverridesSection } from '@/features/dormitories/components'
 import { RoomConfigCSV, AssignmentCSVExport } from '@/features/csv/components'
 import { AssignmentToolbar, AssignmentStats } from '@/features/assignments/components'
 import { SettingsPanel } from '@/features/settings/components'

--- a/src/features/dormitories/components/ApplyPresetModal.vue
+++ b/src/features/dormitories/components/ApplyPresetModal.vue
@@ -1,0 +1,326 @@
+<template>
+  <Modal :model-value="isOpen" :title="modalTitle" max-width="640px" @update:model-value="(v) => !v && cancel()">
+    <div class="form">
+      <p v-if="preset" class="preset-summary">
+        Applying <strong>{{ preset.name }}</strong> will emit {{ preset.entries.length }} override{{ preset.entries.length === 1 ? '' : 's' }}.
+      </p>
+
+      <div class="date-row">
+        <label class="field">
+          <span class="field-label">From</span>
+          <input v-model="effectiveFrom" type="date" />
+        </label>
+        <label class="field">
+          <span class="field-label">To (leave blank for open-ended)</span>
+          <input v-model="effectiveTo" type="date" />
+        </label>
+      </div>
+
+      <label class="field">
+        <span class="field-label">Note (optional)</span>
+        <input v-model="note" type="text" placeholder="e.g. Confirmed by retreat coordinator" />
+      </label>
+
+      <div v-if="dateError" class="warning-banner error">
+        {{ dateError }}
+      </div>
+
+      <div v-if="conflicts.length > 0" class="conflicts">
+        <h4>⚠ {{ conflicts.length }} existing assignment{{ conflicts.length === 1 ? '' : 's' }} will be affected</h4>
+        <p class="conflicts-hint">Applying anyway keeps these guests on their beds with a new warning. You can unassign or move them later.</p>
+        <ul>
+          <li v-for="(c, idx) in conflicts" :key="idx">
+            <strong>{{ c.guestName }}</strong>
+            <span class="dates">{{ c.arrival ?? '?' }} → {{ c.departure ?? '?' }}</span>
+            on <code>{{ c.bedId }}</code>
+            <span class="reason">— {{ c.reason }}</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <template #footer>
+      <button class="btn" @click="cancel">Cancel</button>
+      <button class="btn btn-primary" :disabled="!canApply" @click="apply">
+        {{ conflicts.length > 0 ? `Apply anyway (${conflicts.length})` : 'Apply' }}
+      </button>
+    </template>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import Modal from '@/shared/components/Modal.vue'
+import { useDormitoryStore } from '@/stores/dormitoryStore'
+import { useGuestStore } from '@/stores/guestStore'
+import { useAssignmentStore } from '@/stores/assignmentStore'
+import { staysOverlap } from '@/shared/composables/useUtils'
+import type { OverridePreset, PresetTemplateEntry } from '@/types'
+
+interface Props {
+  isOpen: boolean
+  preset: OverridePreset | null
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{ close: [] }>()
+
+const dormitoryStore = useDormitoryStore()
+const guestStore = useGuestStore()
+const assignmentStore = useAssignmentStore()
+
+const effectiveFrom = ref<string>('')
+const effectiveTo = ref<string>('')
+const note = ref<string>('')
+
+const modalTitle = computed(() => `Apply preset: ${props.preset?.name ?? ''}`)
+
+watch(
+  () => [props.isOpen, props.preset] as const,
+  ([open, preset]) => {
+    if (open && preset) {
+      effectiveFrom.value = todayIso()
+      effectiveTo.value = ''
+      note.value = ''
+    }
+  },
+  { immediate: true }
+)
+
+function todayIso(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+const dateError = computed<string | null>(() => {
+  if (!effectiveFrom.value) return 'Pick a "From" date.'
+  if (effectiveTo.value && effectiveTo.value < effectiveFrom.value) {
+    return '"To" must be on or after "From".'
+  }
+  return null
+})
+
+/**
+ * Beds affected by each entry — used both for the conflict preview AND for the
+ * actual override emission (so the operator sees what they're about to commit).
+ */
+function affectedBedsForEntry(entry: PresetTemplateEntry): string[] {
+  const out: string[] = []
+  for (const dorm of dormitoryStore.dormitories) {
+    if (entry.target.kind === 'dormitory') {
+      if (dorm.dormitoryName !== entry.target.dormitoryName) continue
+      for (const room of dorm.rooms) for (const bed of room.beds) out.push(bed.bedId)
+    } else if (entry.target.kind === 'room') {
+      if (dorm.dormitoryName !== entry.target.dormitoryName) continue
+      for (const room of dorm.rooms) {
+        if (room.roomName !== entry.target.roomName) continue
+        for (const bed of room.beds) out.push(bed.bedId)
+      }
+    } else {
+      for (const room of dorm.rooms) {
+        for (const bed of room.beds) if (bed.bedId === entry.target.bedId) out.push(bed.bedId)
+      }
+    }
+  }
+  return out
+}
+
+interface Conflict {
+  bedId: string
+  guestName: string
+  arrival?: string
+  departure?: string
+  reason: string
+}
+
+const conflicts = computed<Conflict[]>(() => {
+  if (!props.preset || !effectiveFrom.value) return []
+  const window = {
+    arrival: effectiveFrom.value,
+    departure: effectiveTo.value || undefined,
+  }
+  const out: Conflict[] = []
+  const seen = new Set<string>()
+
+  for (const entry of props.preset.entries) {
+    const beds = affectedBedsForEntry(entry)
+    for (const bedId of beds) {
+      const bed = dormitoryStore.getBedById(bedId)
+      if (!bed) continue
+      for (const a of bed.assignments) {
+        const guest = guestStore.getGuestById(a.guestId)
+        if (!guest) continue
+        if (!staysOverlap(guest, window)) continue
+        const dedupeKey = `${bedId}|${a.guestId}|${entry.target.kind}|${entry.change.attr}`
+        if (seen.has(dedupeKey)) continue
+        seen.add(dedupeKey)
+        let reason = ''
+        if (entry.change.attr === 'active' && entry.change.value === false) {
+          reason = `bed becomes inactive (${entry.target.kind} closed)`
+        } else if (entry.change.attr === 'gender') {
+          reason = `room gender → ${entry.change.value}` +
+            (entry.change.value !== guest.gender && entry.change.value !== 'Coed' && guest.gender !== 'Non-binary/Other'
+              ? ` (guest is ${guest.gender})`
+              : '')
+        } else {
+          reason = `${entry.target.kind} ${entry.change.attr} → ${entry.change.value}`
+        }
+        out.push({
+          bedId,
+          guestName: `${guest.firstName} ${guest.lastName}`.trim(),
+          arrival: guest.arrival || undefined,
+          departure: guest.departure || undefined,
+          reason,
+        })
+      }
+    }
+  }
+  return out
+})
+
+const canApply = computed(() => {
+  if (!props.preset) return false
+  if (dateError.value) return false
+  return true
+})
+
+function apply() {
+  if (!props.preset || !canApply.value) return
+  dormitoryStore.applyPreset(
+    props.preset.id,
+    effectiveFrom.value,
+    effectiveTo.value || null,
+    note.value.trim() || undefined
+  )
+  // Silence unused-variable warning — assignmentStore is loaded to register
+  // the store so its assignments are reactive in this scope (used inside
+  // conflicts via getBedById which reads bed.assignments).
+  void assignmentStore
+  emit('close')
+}
+
+function cancel() {
+  emit('close')
+}
+</script>
+
+<style scoped lang="scss">
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.preset-summary {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #374151;
+}
+
+.date-row {
+  display: flex;
+  gap: 12px;
+
+  .field { flex: 1; }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.field-label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+input[type="text"],
+input[type="date"] {
+  padding: 8px 10px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.warning-banner {
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+
+  &.error {
+    background: #fee2e2;
+    border: 1px solid #fca5a5;
+    color: #991b1b;
+  }
+}
+
+.conflicts {
+  border: 1px solid #fde68a;
+  background: #fffbeb;
+  border-radius: 6px;
+  padding: 10px 14px;
+
+  h4 {
+    margin: 0 0 4px 0;
+    font-size: 0.9rem;
+    color: #92400e;
+  }
+
+  .conflicts-hint {
+    margin: 0 0 8px 0;
+    font-size: 0.8rem;
+    color: #92400e;
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 18px;
+    font-size: 0.85rem;
+
+    li {
+      margin-bottom: 3px;
+      color: #1f2937;
+    }
+  }
+
+  .dates {
+    color: #6b7280;
+    margin-left: 6px;
+  }
+
+  code {
+    background: #fef3c7;
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 0.8rem;
+  }
+
+  .reason {
+    color: #92400e;
+    margin-left: 4px;
+  }
+}
+
+.btn {
+  padding: 8px 16px;
+  border: 1px solid #d1d5db;
+  background: white;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  cursor: pointer;
+
+  &:hover { background: #f3f4f6; }
+
+  &.btn-primary {
+    background: #4f46e5;
+    color: white;
+    border-color: #4f46e5;
+
+    &:hover { background: #4338ca; }
+
+    &:disabled { background: #c7d2fe; cursor: not-allowed; }
+  }
+}
+</style>

--- a/src/features/dormitories/components/OneOffOverrideModal.vue
+++ b/src/features/dormitories/components/OneOffOverrideModal.vue
@@ -1,0 +1,122 @@
+<template>
+  <Modal :model-value="isOpen" title="Add one-off override" max-width="640px" @update:model-value="(v) => !v && cancel()">
+    <div class="form">
+      <p class="hint">Use this for a single, untemplated change (e.g. a broken bed, a coordinator's last-minute swap). For repeating configurations, create a preset instead.</p>
+
+      <OverrideEntryEditor
+        v-if="entry"
+        :model-value="entry"
+        :removable="false"
+        @update:model-value="(v) => entry = v"
+      />
+
+      <div class="date-row">
+        <label class="field">
+          <span class="field-label">From</span>
+          <input v-model="effectiveFrom" type="date" />
+        </label>
+        <label class="field">
+          <span class="field-label">To (blank = open-ended)</span>
+          <input v-model="effectiveTo" type="date" />
+        </label>
+      </div>
+
+      <label class="field">
+        <span class="field-label">Note (optional)</span>
+        <input v-model="note" type="text" placeholder="e.g. Heater broken, awaiting repair" />
+      </label>
+
+      <div v-if="dateError" class="warning-banner error">{{ dateError }}</div>
+    </div>
+
+    <template #footer>
+      <button class="btn" @click="cancel">Cancel</button>
+      <button class="btn btn-primary" :disabled="!canApply" @click="apply">Add override</button>
+    </template>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import Modal from '@/shared/components/Modal.vue'
+import OverrideEntryEditor from './OverrideEntryEditor.vue'
+import { useDormitoryStore } from '@/stores/dormitoryStore'
+import type { PresetTemplateEntry } from '@/types'
+
+interface Props {
+  isOpen: boolean
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{ close: [] }>()
+
+const dormitoryStore = useDormitoryStore()
+
+const entry = ref<PresetTemplateEntry | null>(null)
+const effectiveFrom = ref<string>('')
+const effectiveTo = ref<string>('')
+const note = ref<string>('')
+
+watch(
+  () => props.isOpen,
+  open => {
+    if (!open) return
+    const firstDorm = dormitoryStore.dormitories[0]
+    entry.value = {
+      target: { kind: 'dormitory', dormitoryName: firstDorm?.dormitoryName ?? '' },
+      change: { attr: 'active', value: false },
+    }
+    effectiveFrom.value = todayIso()
+    effectiveTo.value = ''
+    note.value = ''
+  },
+  { immediate: true }
+)
+
+function todayIso(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+const dateError = computed<string | null>(() => {
+  if (!effectiveFrom.value) return 'Pick a "From" date.'
+  if (effectiveTo.value && effectiveTo.value < effectiveFrom.value) return '"To" must be on or after "From".'
+  return null
+})
+
+const canApply = computed(() => !!entry.value && !dateError.value)
+
+function apply() {
+  if (!entry.value || !canApply.value) return
+  dormitoryStore.addOverride({
+    target: entry.value.target,
+    change: entry.value.change,
+    effectiveFrom: effectiveFrom.value,
+    effectiveTo: effectiveTo.value || null,
+    note: note.value.trim() || undefined,
+  })
+  emit('close')
+}
+
+function cancel() {
+  emit('close')
+}
+</script>
+
+<style scoped lang="scss">
+.form { display: flex; flex-direction: column; gap: 14px; }
+.hint { margin: 0; font-size: 0.85rem; color: #6b7280; }
+.date-row { display: flex; gap: 12px; .field { flex: 1; } }
+.field { display: flex; flex-direction: column; gap: 4px; }
+.field-label { font-size: 0.8rem; font-weight: 500; color: #374151; }
+input[type="text"], input[type="date"] {
+  padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 4px; font-size: 0.9rem;
+}
+.warning-banner { padding: 8px 12px; border-radius: 6px; font-size: 0.85rem; }
+.warning-banner.error { background: #fee2e2; border: 1px solid #fca5a5; color: #991b1b; }
+.btn { padding: 8px 16px; border: 1px solid #d1d5db; background: white; border-radius: 4px; font-size: 0.9rem; cursor: pointer; }
+.btn:hover { background: #f3f4f6; }
+.btn.btn-primary { background: #4f46e5; color: white; border-color: #4f46e5; }
+.btn.btn-primary:hover { background: #4338ca; }
+.btn.btn-primary:disabled { background: #c7d2fe; cursor: not-allowed; }
+</style>

--- a/src/features/dormitories/components/OverrideEntryEditor.vue
+++ b/src/features/dormitories/components/OverrideEntryEditor.vue
@@ -1,0 +1,181 @@
+<template>
+  <div class="entry-row">
+    <select v-model="kind" class="kind-select">
+      <option value="dormitory">Dormitory</option>
+      <option value="room">Room</option>
+      <option value="bed">Bed</option>
+    </select>
+
+    <select v-model="targetKey" class="target-select">
+      <option value="" disabled>Pick a {{ kind }}…</option>
+      <option v-for="opt in targetOptions" :key="opt.key" :value="opt.key">
+        {{ opt.label }}
+      </option>
+    </select>
+
+    <span class="separator">→</span>
+
+    <select v-model="attr" class="attr-select">
+      <option value="active">{{ kind === 'room' ? 'Open / Closed' : 'Open / Closed' }}</option>
+      <option v-if="kind === 'room'" value="gender">Gender</option>
+    </select>
+
+    <select v-if="attr === 'active'" v-model="activeValue" class="value-select">
+      <option :value="true">Open</option>
+      <option :value="false">Closed</option>
+    </select>
+
+    <select v-else-if="attr === 'gender'" v-model="genderValue" class="value-select">
+      <option value="M">M</option>
+      <option value="F">F</option>
+      <option value="Coed">Coed</option>
+    </select>
+
+    <button v-if="removable" type="button" class="remove-btn" @click="$emit('remove')" title="Remove entry">×</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useDormitoryStore } from '@/stores/dormitoryStore'
+import type { OverrideTarget, OverrideAttribute, RoomGender, PresetTemplateEntry } from '@/types'
+
+interface Props {
+  modelValue: PresetTemplateEntry | null
+  removable?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), { removable: true })
+const emit = defineEmits<{
+  'update:modelValue': [value: PresetTemplateEntry]
+  remove: []
+}>()
+
+const dormitoryStore = useDormitoryStore()
+
+const kind = ref<'dormitory' | 'room' | 'bed'>(props.modelValue?.target.kind ?? 'dormitory')
+const targetKey = ref<string>(initialTargetKey())
+const attr = ref<'active' | 'gender'>(props.modelValue?.change.attr ?? 'active')
+const activeValue = ref<boolean>(
+  props.modelValue?.change.attr === 'active' ? props.modelValue.change.value : false
+)
+const genderValue = ref<RoomGender>(
+  props.modelValue?.change.attr === 'gender' ? props.modelValue.change.value : 'Coed'
+)
+
+function initialTargetKey(): string {
+  const t = props.modelValue?.target
+  if (!t) return ''
+  if (t.kind === 'dormitory') return `dorm::${t.dormitoryName}`
+  if (t.kind === 'room') return `room::${t.dormitoryName}::${t.roomName}`
+  return `bed::${t.bedId}`
+}
+
+const targetOptions = computed(() => {
+  const out: { key: string; label: string }[] = []
+  if (kind.value === 'dormitory') {
+    for (const d of dormitoryStore.dormitories) {
+      out.push({ key: `dorm::${d.dormitoryName}`, label: d.dormitoryName })
+    }
+  } else if (kind.value === 'room') {
+    for (const d of dormitoryStore.dormitories) {
+      for (const r of d.rooms) {
+        out.push({
+          key: `room::${d.dormitoryName}::${r.roomName}`,
+          label: `${d.dormitoryName} — ${r.roomName}`,
+        })
+      }
+    }
+  } else {
+    for (const d of dormitoryStore.dormitories) {
+      for (const r of d.rooms) {
+        for (const b of r.beds) {
+          out.push({
+            key: `bed::${b.bedId}`,
+            label: `${b.bedId} (${d.dormitoryName} / ${r.roomName})`,
+          })
+        }
+      }
+    }
+  }
+  return out
+})
+
+// When kind changes, clear the specific target (it likely no longer matches).
+watch(kind, () => {
+  targetKey.value = ''
+  // Room is the only kind that allows the gender attr; reset if needed.
+  if (kind.value !== 'room' && attr.value === 'gender') attr.value = 'active'
+})
+
+function parseTargetKey(key: string): OverrideTarget | null {
+  if (!key) return null
+  const parts = key.split('::')
+  if (parts[0] === 'dorm') return { kind: 'dormitory', dormitoryName: parts[1] }
+  if (parts[0] === 'room') return { kind: 'room', dormitoryName: parts[1], roomName: parts[2] }
+  if (parts[0] === 'bed') return { kind: 'bed', bedId: parts[1] }
+  return null
+}
+
+watch(
+  [kind, targetKey, attr, activeValue, genderValue],
+  () => {
+    const target = parseTargetKey(targetKey.value)
+    if (!target) return
+    let change: OverrideAttribute
+    if (attr.value === 'active') {
+      change = { attr: 'active', value: activeValue.value }
+    } else {
+      change = { attr: 'gender', value: genderValue.value }
+    }
+    emit('update:modelValue', { target, change })
+  },
+  { deep: true }
+)
+</script>
+
+<style scoped lang="scss">
+.entry-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 8px;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+
+select {
+  padding: 4px 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: white;
+  font-size: 0.85rem;
+}
+
+.kind-select { min-width: 100px; }
+.target-select { min-width: 200px; flex: 1; }
+.attr-select { min-width: 120px; }
+.value-select { min-width: 80px; }
+
+.separator {
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.remove-btn {
+  margin-left: auto;
+  border: none;
+  background: transparent;
+  color: #ef4444;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 6px;
+  border-radius: 4px;
+
+  &:hover { background: #fee2e2; }
+}
+</style>

--- a/src/features/dormitories/components/PresetEditModal.vue
+++ b/src/features/dormitories/components/PresetEditModal.vue
@@ -1,0 +1,183 @@
+<template>
+  <Modal :model-value="isOpen" :title="modalTitle" max-width="720px" @update:model-value="(v) => !v && cancel()">
+    <div class="form">
+      <label class="field">
+        <span class="field-label">Name</span>
+        <input v-model="name" type="text" placeholder="e.g. Women's Retreat" />
+      </label>
+
+      <label class="field">
+        <span class="field-label">Description (optional)</span>
+        <input v-model="description" type="text" placeholder="e.g. North wing closed, Maple Hall switches to F" />
+      </label>
+
+      <div class="field">
+        <span class="field-label">What changes when this preset is applied?</span>
+        <div class="entries">
+          <OverrideEntryEditor
+            v-for="(entry, idx) in entries"
+            :key="idx"
+            :model-value="entry"
+            @update:model-value="(v) => entries[idx] = v"
+            @remove="removeEntry(idx)"
+          />
+          <button type="button" class="add-entry-btn" @click="addEntry">+ Add change</button>
+        </div>
+      </div>
+    </div>
+
+    <template #footer>
+      <button class="btn" @click="cancel">Cancel</button>
+      <button class="btn btn-primary" :disabled="!canSave" @click="save">{{ isEditing ? 'Save' : 'Create preset' }}</button>
+    </template>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import Modal from '@/shared/components/Modal.vue'
+import OverrideEntryEditor from './OverrideEntryEditor.vue'
+import { useDormitoryStore } from '@/stores/dormitoryStore'
+import type { OverridePreset, PresetTemplateEntry } from '@/types'
+
+interface Props {
+  isOpen: boolean
+  /** The preset being edited; null = creating a new one. */
+  preset: OverridePreset | null
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{ close: [] }>()
+
+const dormitoryStore = useDormitoryStore()
+
+const name = ref('')
+const description = ref('')
+const entries = ref<PresetTemplateEntry[]>([])
+
+const isEditing = computed(() => props.preset !== null)
+const modalTitle = computed(() => (isEditing.value ? 'Edit preset' : 'New preset'))
+const canSave = computed(() => name.value.trim().length > 0 && entries.value.length > 0)
+
+watch(
+  () => [props.isOpen, props.preset] as const,
+  ([open, preset]) => {
+    if (!open) return
+    if (preset) {
+      name.value = preset.name
+      description.value = preset.description ?? ''
+      // Deep clone so edits don't mutate the live preset until Save.
+      entries.value = preset.entries.map(e => ({ target: { ...e.target }, change: { ...e.change } } as PresetTemplateEntry))
+    } else {
+      name.value = ''
+      description.value = ''
+      entries.value = []
+    }
+  },
+  { immediate: true }
+)
+
+function addEntry() {
+  const firstDorm = dormitoryStore.dormitories[0]
+  entries.value.push({
+    target: { kind: 'dormitory', dormitoryName: firstDorm?.dormitoryName ?? '' },
+    change: { attr: 'active', value: false },
+  })
+}
+
+function removeEntry(idx: number) {
+  entries.value.splice(idx, 1)
+}
+
+function save() {
+  if (!canSave.value) return
+  if (isEditing.value && props.preset) {
+    dormitoryStore.updatePreset(props.preset.id, {
+      name: name.value.trim(),
+      description: description.value.trim() || undefined,
+      entries: entries.value,
+    })
+  } else {
+    dormitoryStore.addPreset({
+      name: name.value.trim(),
+      description: description.value.trim() || undefined,
+      entries: entries.value,
+    })
+  }
+  emit('close')
+}
+
+function cancel() {
+  emit('close')
+}
+</script>
+
+<style scoped lang="scss">
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+input[type="text"] {
+  padding: 8px 10px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.entries {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.add-entry-btn {
+  align-self: flex-start;
+  padding: 6px 12px;
+  border: 1px dashed #9ca3af;
+  background: white;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  color: #374151;
+  cursor: pointer;
+
+  &:hover { border-color: #4f46e5; color: #4f46e5; }
+}
+
+.btn {
+  padding: 8px 16px;
+  border: 1px solid #d1d5db;
+  background: white;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  cursor: pointer;
+
+  &:hover { background: #f3f4f6; }
+
+  &.btn-primary {
+    background: #4f46e5;
+    color: white;
+    border-color: #4f46e5;
+
+    &:hover { background: #4338ca; }
+
+    &:disabled {
+      background: #c7d2fe;
+      cursor: not-allowed;
+    }
+  }
+}
+</style>

--- a/src/features/dormitories/components/PresetsAndOverridesSection.vue
+++ b/src/features/dormitories/components/PresetsAndOverridesSection.vue
@@ -1,0 +1,411 @@
+<template>
+  <section class="presets-overrides">
+    <header class="section-header">
+      <h3>Time-based overrides</h3>
+      <p class="section-hint">Define dated changes to the base layout. Use <strong>presets</strong> for repeating retreat configurations and <strong>one-off overrides</strong> for last-minute tweaks. Effective on the View Date in Table View.</p>
+    </header>
+
+    <!-- Presets -->
+    <div class="card">
+      <div class="card-header">
+        <h4>Presets</h4>
+        <button class="btn-small" @click="openNewPreset">+ New preset</button>
+      </div>
+      <div v-if="presets.length === 0" class="empty">
+        No presets yet. Create one for repeating layouts (e.g. "Women's Retreat", "Winter Mode").
+      </div>
+      <ul v-else class="preset-list">
+        <li v-for="preset in presets" :key="preset.id">
+          <div class="preset-row">
+            <div class="preset-main">
+              <strong>{{ preset.name }}</strong>
+              <span class="preset-desc" v-if="preset.description">— {{ preset.description }}</span>
+              <span class="preset-meta">{{ preset.entries.length }} change{{ preset.entries.length === 1 ? '' : 's' }}</span>
+            </div>
+            <div class="preset-actions">
+              <button class="btn-small" @click="openApply(preset)" :disabled="preset.entries.length === 0">Apply…</button>
+              <button class="btn-small" @click="openEdit(preset)">Edit</button>
+              <button class="btn-small btn-danger" @click="confirmDeletePreset(preset)">Delete</button>
+            </div>
+          </div>
+          <ul v-if="applicationsForPreset(preset.id).length > 0" class="applications">
+            <li v-for="app in applicationsForPreset(preset.id)" :key="app.applicationId">
+              <span class="app-window">{{ formatDate(app.effectiveFrom) }} → {{ app.effectiveTo ? formatDate(app.effectiveTo) : '∞' }}</span>
+              <span class="app-count">({{ app.count }} override{{ app.count === 1 ? '' : 's' }})</span>
+              <button class="btn-mini btn-danger" @click="revertApplication(app.applicationId, preset.name)">Revert</button>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Overrides timeline -->
+    <div class="card">
+      <div class="card-header">
+        <h4>All overrides</h4>
+        <button class="btn-small" @click="openOneOff">+ Add one-off</button>
+      </div>
+      <div v-if="overrides.length === 0" class="empty">
+        No overrides yet.
+      </div>
+      <ul v-else class="overrides-list">
+        <li v-for="o in sortedOverrides" :key="o.id" class="override-row">
+          <span class="window">{{ formatDate(o.effectiveFrom) }} → {{ o.effectiveTo ? formatDate(o.effectiveTo) : '∞' }}</span>
+          <span class="target">{{ targetLabel(o.target) }}</span>
+          <span class="separator">→</span>
+          <span class="change">{{ changeLabel(o.change) }}</span>
+          <span v-if="o.presetId" class="source preset-source" :title="presetNameFor(o.presetId) ?? ''">
+            from preset: {{ presetNameFor(o.presetId) ?? '(deleted)' }}
+          </span>
+          <span v-else class="source oneoff-source">one-off</span>
+          <span v-if="o.note" class="note" :title="o.note">📝</span>
+          <button class="btn-mini btn-danger" @click="deleteOverride(o.id)" title="Delete this override">×</button>
+        </li>
+      </ul>
+    </div>
+
+    <PresetEditModal :is-open="editModalOpen" :preset="editTarget" @close="editModalOpen = false" />
+    <ApplyPresetModal :is-open="applyModalOpen" :preset="applyTarget" @close="applyModalOpen = false" />
+    <OneOffOverrideModal :is-open="oneOffModalOpen" @close="oneOffModalOpen = false" />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useDormitoryStore } from '@/stores/dormitoryStore'
+import PresetEditModal from './PresetEditModal.vue'
+import ApplyPresetModal from './ApplyPresetModal.vue'
+import OneOffOverrideModal from './OneOffOverrideModal.vue'
+import type { OverridePreset, OverrideTarget, OverrideAttribute } from '@/types'
+
+const dormitoryStore = useDormitoryStore()
+
+const presets = computed(() => dormitoryStore.presets)
+const overrides = computed(() => dormitoryStore.overrides)
+
+const sortedOverrides = computed(() => {
+  return [...overrides.value].sort((a, b) => a.effectiveFrom.localeCompare(b.effectiveFrom))
+})
+
+const editModalOpen = ref(false)
+const editTarget = ref<OverridePreset | null>(null)
+const applyModalOpen = ref(false)
+const applyTarget = ref<OverridePreset | null>(null)
+const oneOffModalOpen = ref(false)
+
+function openNewPreset() {
+  editTarget.value = null
+  editModalOpen.value = true
+}
+
+function openEdit(preset: OverridePreset) {
+  editTarget.value = preset
+  editModalOpen.value = true
+}
+
+function openApply(preset: OverridePreset) {
+  applyTarget.value = preset
+  applyModalOpen.value = true
+}
+
+function openOneOff() {
+  oneOffModalOpen.value = true
+}
+
+function confirmDeletePreset(preset: OverridePreset) {
+  const applied = applicationsForPreset(preset.id).length
+  const msg = applied > 0
+    ? `Delete preset "${preset.name}"? This will also delete ${applied} applied window${applied === 1 ? '' : 's'} (every override sourced from this preset).`
+    : `Delete preset "${preset.name}"?`
+  if (window.confirm(msg)) {
+    dormitoryStore.deletePreset(preset.id)
+  }
+}
+
+function deleteOverride(id: string) {
+  if (window.confirm('Delete this override?')) dormitoryStore.deleteOverride(id)
+}
+
+function revertApplication(applicationId: string, presetName: string) {
+  if (window.confirm(`Revert this application of "${presetName}"? All overrides from this window will be deleted.`)) {
+    dormitoryStore.revertPresetApplication(applicationId)
+  }
+}
+
+interface PresetApplication {
+  applicationId: string
+  effectiveFrom: string
+  effectiveTo: string | null
+  count: number
+}
+
+/**
+ * Group overrides by applicationId so each "this preset was applied for
+ * Jul 4 → Jul 11" surfaces as one revertable row. Same preset applied to
+ * multiple non-overlapping windows shows multiple rows.
+ */
+function applicationsForPreset(presetId: string): PresetApplication[] {
+  const byApp = new Map<string, PresetApplication>()
+  for (const o of overrides.value) {
+    if (o.presetId !== presetId || !o.applicationId) continue
+    const existing = byApp.get(o.applicationId)
+    if (existing) {
+      existing.count++
+    } else {
+      byApp.set(o.applicationId, {
+        applicationId: o.applicationId,
+        effectiveFrom: o.effectiveFrom,
+        effectiveTo: o.effectiveTo,
+        count: 1,
+      })
+    }
+  }
+  return [...byApp.values()].sort((a, b) => a.effectiveFrom.localeCompare(b.effectiveFrom))
+}
+
+function presetNameFor(presetId: string): string | null {
+  return presets.value.find(p => p.id === presetId)?.name ?? null
+}
+
+function targetLabel(t: OverrideTarget): string {
+  if (t.kind === 'dormitory') return `Dormitory: ${t.dormitoryName}`
+  if (t.kind === 'room') return `Room: ${t.dormitoryName} / ${t.roomName}`
+  return `Bed: ${t.bedId}`
+}
+
+function changeLabel(c: OverrideAttribute): string {
+  if (c.attr === 'active') return c.value ? 'Open' : 'Closed'
+  return `Gender: ${c.value}`
+}
+
+function formatDate(iso: string): string {
+  // Render YYYY-MM-DD as "Mon DD" or "Mon DD, YYYY" if year differs from current.
+  const [y, m, d] = iso.split('-').map(Number)
+  if (!y || !m || !d) return iso
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  return `${months[m - 1]} ${d}, ${y}`
+}
+</script>
+
+<style scoped lang="scss">
+.presets-overrides {
+  padding: 0 16px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section-header {
+  h3 {
+    margin: 0 0 4px 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #1f2937;
+  }
+
+  .section-hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #6b7280;
+  }
+}
+
+.card {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e5e7eb;
+  background: #f9fafb;
+
+  h4 {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #374151;
+  }
+}
+
+.empty {
+  padding: 16px;
+  font-size: 0.85rem;
+  color: #6b7280;
+  text-align: center;
+}
+
+.preset-list,
+.overrides-list,
+.applications {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.preset-list > li {
+  padding: 10px 16px;
+  border-bottom: 1px solid #f3f4f6;
+
+  &:last-child { border-bottom: none; }
+}
+
+.preset-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.preset-main {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+  flex: 1;
+  min-width: 0;
+
+  .preset-desc {
+    font-size: 0.85rem;
+    color: #6b7280;
+  }
+
+  .preset-meta {
+    font-size: 0.75rem;
+    color: #9ca3af;
+    background: #f3f4f6;
+    padding: 1px 6px;
+    border-radius: 8px;
+  }
+}
+
+.preset-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.applications {
+  margin-top: 6px;
+  padding: 6px 10px;
+  background: #fef3c7;
+  border-radius: 4px;
+  font-size: 0.8rem;
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 0;
+    color: #92400e;
+  }
+
+  .app-window {
+    font-weight: 500;
+  }
+
+  .app-count {
+    color: #b45309;
+  }
+}
+
+.override-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-bottom: 1px solid #f3f4f6;
+  font-size: 0.85rem;
+
+  &:last-child { border-bottom: none; }
+
+  .window {
+    color: #374151;
+    font-weight: 500;
+    min-width: 180px;
+  }
+
+  .target {
+    color: #1f2937;
+  }
+
+  .separator {
+    color: #9ca3af;
+  }
+
+  .change {
+    color: #4f46e5;
+    font-weight: 500;
+  }
+
+  .source {
+    margin-left: auto;
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 10px;
+
+    &.preset-source {
+      background: #ede9fe;
+      color: #6d28d9;
+    }
+
+    &.oneoff-source {
+      background: #f3f4f6;
+      color: #6b7280;
+    }
+  }
+
+  .note {
+    cursor: help;
+  }
+}
+
+.btn-small {
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  border: 1px solid #d1d5db;
+  background: white;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover { background: #f3f4f6; }
+
+  &:disabled {
+    color: #9ca3af;
+    cursor: not-allowed;
+    background: #f9fafb;
+  }
+
+  &.btn-danger {
+    color: #b91c1c;
+    border-color: #fca5a5;
+
+    &:hover { background: #fee2e2; }
+  }
+}
+
+.btn-mini {
+  padding: 2px 8px;
+  font-size: 0.75rem;
+  border: 1px solid #d1d5db;
+  background: white;
+  border-radius: 4px;
+  cursor: pointer;
+  line-height: 1;
+
+  &:hover { background: #f3f4f6; }
+
+  &.btn-danger {
+    color: #b91c1c;
+    border-color: #fca5a5;
+
+    &:hover { background: #fee2e2; }
+  }
+}
+</style>

--- a/src/features/dormitories/components/index.ts
+++ b/src/features/dormitories/components/index.ts
@@ -16,3 +16,10 @@ export { default as BedConfigItem } from './BedConfigItem.vue'
 // Layout management components
 export { default as LayoutSelector } from './LayoutSelector.vue'
 export { default as NewLayoutModal } from './NewLayoutModal.vue'
+
+// Time-based overrides + presets
+export { default as PresetsAndOverridesSection } from './PresetsAndOverridesSection.vue'
+export { default as PresetEditModal } from './PresetEditModal.vue'
+export { default as ApplyPresetModal } from './ApplyPresetModal.vue'
+export { default as OneOffOverrideModal } from './OneOffOverrideModal.vue'
+export { default as OverrideEntryEditor } from './OverrideEntryEditor.vue'

--- a/src/stores/validationStore.overrideConflict.test.ts
+++ b/src/stores/validationStore.overrideConflict.test.ts
@@ -1,0 +1,120 @@
+/**
+ * overrideConflict warning surfaces on an assignment whose bed/room/dorm
+ * becomes inactive during the guest's stay via a time-based override.
+ * The bed stays assigned (per spec — non-blocking warning, operator
+ * decides when to re-place).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useGuestStore } from './guestStore'
+import { useDormitoryStore } from './dormitoryStore'
+import { useAssignmentStore } from './assignmentStore'
+import { useSettingsStore } from './settingsStore'
+import { useValidationStore } from './validationStore'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { store = {} },
+    key: () => null,
+    length: 0,
+  }
+})()
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+if (typeof globalThis.crypto === 'undefined') {
+  ;(globalThis as { crypto: Crypto }).crypto = {
+    randomUUID: () => Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`,
+  } as Crypto
+} else if (typeof globalThis.crypto.randomUUID !== 'function') {
+  globalThis.crypto.randomUUID = () =>
+    Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`
+}
+
+function seed() {
+  const dorm = useDormitoryStore()
+  dorm.importDormitories([
+    {
+      dormitoryName: 'Test Dorm',
+      active: true,
+      rooms: [
+        {
+          roomName: 'Test Room',
+          roomGender: 'M',
+          active: true,
+          beds: [{ bedId: 'B01', bedType: 'single', position: 1, assignments: [] }],
+        },
+      ],
+    },
+  ])
+  const guest = useGuestStore().addGuest({
+    firstName: 'Alice',
+    lastName: 'T',
+    gender: 'M',
+    age: 30,
+    arrival: '2026-07-10',
+    departure: '2026-07-15',
+    indivGrp: 'individual',
+  })
+  useAssignmentStore().assignGuestToBed(guest.id, 'B01', true)
+  return { guest, dorm }
+}
+
+describe('validationStore — overrideConflict warning', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+    useSettingsStore().settings.warnings.genderMismatch = true
+  })
+
+  it('flags an assignment when a bed-level override closes the bed during the stay', () => {
+    const { dorm } = seed()
+    dorm.addOverride({
+      target: { kind: 'bed', bedId: 'B01' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-12',
+      effectiveTo: '2026-07-14',
+    })
+    const warnings = useValidationStore().getWarningsForBed('B01')
+    expect(warnings.some(w => /inactive.*override/i.test(w))).toBe(true)
+  })
+
+  it('does NOT flag when override window is outside the stay', () => {
+    const { dorm } = seed()
+    dorm.addOverride({
+      target: { kind: 'bed', bedId: 'B01' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-08-01',
+      effectiveTo: '2026-08-15',
+    })
+    const warnings = useValidationStore().getWarningsForBed('B01')
+    expect(warnings.some(w => /inactive.*override/i.test(w))).toBe(false)
+  })
+
+  it('flags when a dormitory-level override cascades to close the bed during the stay', () => {
+    const { dorm } = seed()
+    dorm.addOverride({
+      target: { kind: 'dormitory', dormitoryName: 'Test Dorm' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-11',
+      effectiveTo: '2026-07-13',
+    })
+    const warnings = useValidationStore().getWarningsForBed('B01')
+    expect(warnings.some(w => /inactive.*override/i.test(w))).toBe(true)
+  })
+
+  it('does not unassign the guest — assignment persists despite the warning', () => {
+    const { guest, dorm } = seed()
+    dorm.addOverride({
+      target: { kind: 'bed', bedId: 'B01' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-12',
+      effectiveTo: '2026-07-14',
+    })
+    expect(useAssignmentStore().getAssignmentByGuest(guest.id)).toBe('B01')
+  })
+})

--- a/src/stores/validationStore.ts
+++ b/src/stores/validationStore.ts
@@ -155,6 +155,14 @@ export const useValidationStore = defineStore('validation', () => {
       warnings.push('Needs Lower Bunk')
     }
 
+    // Override conflict: a time-based override has made this bed (or its
+    // room/dorm) inactive at some point during the guest's stay. Doesn't
+    // auto-unassign — surfaces a non-blocking warning so the operator can
+    // re-place the guest at their own pace.
+    if (!dormitoryStore.isBedActiveDuringStay(bed.bedId, guest.arrival, guest.departure)) {
+      warnings.push('Bed inactive during stay (override active)')
+    }
+
     // Check for family/group separation warnings - DISABLED
     // if (
     //   settingsStore.settings.warnings.familySeparation &&


### PR DESCRIPTION
## Summary
Closes the loop on the time-based override feature (specs/TimeBasedRoomConfig.md). Operators can now create presets, apply them with conflict awareness, and manage one-off overrides — all from a new section in the Room Configuration tab.

### New UI (Room Configuration tab)
- **Presets card** — list of saved preset templates with **Apply / Edit / Delete** per row. Applied windows expand inline showing each application's date range + Revert button. Same preset applied to two windows reverts independently.
- **All overrides timeline** — flat list of every active/future override sorted by date. Shows window, target (Dormitory/Room/Bed), change, source (preset or one-off), optional note, and delete button.
- **PresetEditModal** — name + description + dynamic list of (target, change) entries via a shared `OverrideEntryEditor`.
- **ApplyPresetModal** — from/to date picker. Computes existing-assignment conflicts inside the window and surfaces them in a summary-style dialog. Apply still proceeds — affected assignments stay put and get the new `overrideConflict` warning so the operator can re-place at their own pace.
- **OneOffOverrideModal** — single-entry form for untemplated tweaks ("heater broken", "last-minute coordinator swap").

### New validation category
`validationStore`: `overrideConflict` warning. When a guest's assignment falls in a window where the bed (or its room/dorm) is inactive via override, the slot surfaces *"Bed inactive during stay (override active)"*. Non-blocking — assignments persist.

### Smoke-tested end-to-end
Created a preset closing Maple Hall, applied for today onward, switched to Table View: override banner appears, Maple Hall vanishes, Pine Cabin renders normally. Reverting from the Configuration tab restores Maple Hall on next reload.

## Test plan
- [x] 4 new tests cover the `overrideConflict` warning (bed-level + dorm-level + outside-window passthrough + assignment persistence).
- [x] Full suite passes (123/123).
- [x] `npm run build` clean.
- [x] Dev smoke: create preset → apply → Table View reflects override; revert restores.
- [ ] Netlify preview manual check on a fresh session.

## Deferred / known limitations
- Right-click "Add override" from a Table View bed/room/dorm — nice-to-have, deferred.
- Timeline view per-day hatching for inactive windows — TimelineView is large and deserves its own pass.
- JSON export/import of overrides + presets — exists in localStorage already; round-trip via export needs a small extension to `RoomConfigCSV`.
- Migration from the older multi-layout state — proposed in the spec but not yet implemented (existing operators with 1 layout are unaffected; multi-layout users can keep using both side-by-side until we ship the diff-to-preset migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)