### PR TITLE
Configuration cuts — timeline of full configurations (rename + remodel)

### DIFF
--- a/specs/ConfigurationCuts.md
+++ b/specs/ConfigurationCuts.md
@@ -1,0 +1,349 @@
+# Spec: Configuration Cuts (timeline of full configurations)
+
+**Status:** Draft
+**Date:** 2026-06-14
+**Supersedes:** [`TimeBasedRoomConfig.md`](./TimeBasedRoomConfig.md) and the
+"base + dated overrides" data model shipped in PRs #40 / #41 / #42 / #43 / #44.
+Layouts (deprecated in PR #44) stay deprecated.
+
+## Purpose & User Problem
+
+The override model ("base config + dated overrides + preset templates") was
+mathematically correct but cognitively confusing. Operators don't think
+"this is the base, and on Jul 4 an override flips Maple Hall closed."
+They think:
+
+> "Right now we're in our default setup. On Jul 4 we cut over to the
+> Women's Retreat setup. On Jul 12 we cut back. Each of those is just…
+> a configuration of the property at that time."
+
+That mental model — **a timeline of independent full configurations,
+chained by cut points** — is much closer to how operators describe it.
+It's also closer to how Premiere editors think about clips: each clip
+is a complete thing; you slice the timeline to introduce a new one.
+
+## Mental model
+
+- The property has **one timeline** of configurations.
+- At any moment in time, **exactly one** Configuration is in effect.
+- A Configuration is a **full snapshot** of `dormitories[]` (dorms, rooms,
+  beds, attributes). Not a delta. Not deltas-on-top-of-a-base.
+- The fundamental editing action is a **Cut at date D**. It splits the
+  Configuration covering D into two segments:
+  - `[…D − 1]` keeps the original snapshot.
+  - `[D…]` starts as a **copy** of that snapshot and is then edited
+    independently.
+- Cuts can be added anywhere on the timeline. Cutting inside an existing
+  future segment splits it further: the original `[D₁ … D₂]` becomes
+  `[D₁ … D₃ − 1][D₃ … D₂]` where D₃ is the new cut.
+- Deleting a cut merges the two adjacent segments into one. The
+  **earlier** segment's snapshot wins (the later snapshot is discarded
+  after a confirm).
+- Past configurations are editable — fix a typo, retroactively record
+  what was actually true.
+
+A small but important corollary: there is always at least one
+Configuration (the "initial" one, with `effectiveFrom: null` meaning
+"from the start of time"). You can't delete every cut — the timeline
+must have at least one Configuration covering all of time.
+
+## Renames
+
+| Old | New |
+|---|---|
+| Override / one-off | (gone — only Configurations + cuts) |
+| Preset | Configuration template |
+| Override timeline | Configuration timeline |
+| "+ Add one-off" | "+ Cut here" |
+| "Apply preset" | "Cut + use template" |
+| "Custom" segment label | (gone — every segment is just its own Configuration) |
+| `dormitoryStore.overrides[]` | `dormitoryStore.configurations[]` |
+| `dormitoryStore.presets[]` | `dormitoryStore.configurationTemplates[]` |
+
+Everything operator-visible drops "override" and "preset" — the only
+words on screen are **Configuration**, **Cut**, **Template**.
+
+## Data model
+
+```typescript
+interface TimelineConfiguration {
+  id: string
+  /**
+   * Inclusive start date (ISO YYYY-MM-DD). `null` means "from the
+   * start of time" — there is exactly one such configuration, the
+   * initial one. Sort order is `effectiveFrom` ascending with the
+   * `null` (initial) one always first.
+   */
+  effectiveFrom: string | null
+  /** Operator-visible name. Defaults to e.g. "Configuration 3". */
+  name: string
+  /** Full snapshot. */
+  dormitories: Dormitory[]
+  createdAt: string
+  updatedAt: string
+}
+
+interface ConfigurationTemplate {
+  id: string
+  name: string
+  description?: string
+  dormitories: Dormitory[]
+  createdAt: string
+}
+```
+
+`dormitoryStore` state becomes:
+
+```typescript
+configurations: TimelineConfiguration[]  // sorted by effectiveFrom (null first)
+configurationTemplates: ConfigurationTemplate[]
+```
+
+Note the absence of `overrides[]`, `presets[]`, and the per-attribute
+override resolution code. `dormitoriesAt(date)` becomes a one-liner:
+find the configuration whose `[effectiveFrom, nextEffectiveFrom)`
+window covers `date`, return its `dormitories`.
+
+## Core operations
+
+### `cutAt(date: string, options?)`
+
+Effect:
+1. Find the configuration `C` whose window covers `date`.
+2. If `C.effectiveFrom === date`, do nothing (cut already exists there).
+3. Otherwise, deep-clone `C.dormitories`, create a new
+   `TimelineConfiguration` with `effectiveFrom = date` and the cloned
+   tree. Auto-name it (e.g. `"Configuration 3"`).
+4. Insert in the sorted array.
+
+Options:
+- `copyFrom: id` — copy the new segment's snapshot from a different
+  configuration's snapshot instead of `C`'s. Used by the "Copy from…"
+  workflow when creating a cut.
+- `name: string` — set a name immediately.
+- `templateId: id` — copy from a `ConfigurationTemplate` (functionally
+  same as `copyFrom` but on the template library).
+
+### `deleteCut(configurationId: string)`
+
+Effect:
+1. Refuse if `configurationId` is the initial configuration
+   (`effectiveFrom === null`). The timeline always needs a base.
+2. Otherwise, remove it from the array. The previous configuration's
+   window naturally extends to the next cut. The deleted snapshot is
+   discarded (confirm dialog explains).
+
+### `updateConfigurationDormitories(configurationId, dormitories[])`
+
+Used by the Configuration tab's dormitory editor when a specific
+configuration is selected for editing. Directly replaces that
+configuration's snapshot.
+
+### Template operations
+
+- `saveConfigurationAsTemplate(configurationId, name)` — clone the
+  config's snapshot into `configurationTemplates`.
+- `applyTemplateAsCut(templateId, date)` — sugar for
+  `cutAt(date, { templateId })`.
+- `copyConfigurationToCut(sourceId, date)` — sugar for
+  `cutAt(date, { copyFrom: sourceId })`.
+
+## UX
+
+### Configuration tab — top-level structure
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Configuration timeline                                       │
+│  [From: …] [To: …]                          [+ Cut here…]    │
+│  ┌──────────────────────────────────────────────────────────┐│
+│  │[ Default ][ Women's Retreat ][ Default ][ Winter Mode  ] ││
+│  └──────────────────────────────────────────────────────────┘│
+│  ↑ today indicator                                            │
+│                                                               │
+│  Editing: Women's Retreat  (Jul 4 – Jul 11)        [Rename]  │
+│  ──────────────────────────────────────────────────────────── │
+│  [ dormitory / room / bed editor for THIS configuration ]    │
+│                                                               │
+└──────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│  Templates                                  [+ New template] │
+│  • Women's Retreat (matches Jul 4 cut)        [Apply…][…]   │
+│  • Winter Mode                                [Apply…][…]   │
+└──────────────────────────────────────────────────────────────┘
+```
+
+- **Top: the timeline bar.** Same segmented bar as today, same
+  signature-stable coloring. Clicking a segment **selects** that
+  configuration as the editing target. The dormitory editor below
+  then reflects (and writes to) that selected configuration.
+- **Cut here** opens a small popover: date input (defaults to the
+  selected segment's start, or today), name input (optional), and a
+  picker: `Empty copy of current ▾ | Copy from another configuration | Use template`.
+- **Templates card** below: save / apply / rename. Apply = cut at a
+  chosen date + populate from the template.
+
+### Cut popover details
+
+Three "source" choices:
+
+1. **Empty copy of current configuration** (default). New segment starts
+   identical to the one being cut, then you edit it.
+2. **Copy from another configuration** — dropdown of every existing
+   configuration on the timeline. New segment starts as a copy of that
+   one's snapshot.
+3. **Use template** — dropdown of `configurationTemplates`. New segment
+   starts from the template snapshot.
+
+In all three cases, the result is a fresh independent snapshot — no
+ongoing "link" to the source. Editing the source later does NOT update
+this cut. This matches operator expectation: "I cut over to Women's
+Retreat last July" means "I copied the Women's Retreat setup then; if I
+update the template now, last July's cut isn't retroactively edited."
+
+### Segment selection vs. View Date
+
+Two related but distinct things:
+
+- **View Date** (Table View): "show me what the property looks like on
+  this date." Resolves to whichever configuration's window covers that
+  date.
+- **Editing Target** (Configuration tab): "I want to edit this
+  configuration." Selected by clicking the timeline segment.
+
+Default editing target = the configuration covering today. Clicking a
+different segment switches the target.
+
+### Delete-cut affordance
+
+Clicking a selected non-initial segment surfaces a "Delete this cut"
+button. Confirm dialog: "This will merge `<name>` back into
+`<previous-name>` and discard its snapshot. Continue?"
+
+## Migration from PR #40-#44 state
+
+Auto-migrate on first load:
+
+1. If `dormitoryStore.configurations` already exists, skip.
+2. Otherwise, compute the **segment list** the way `buildSegments` did,
+   over the union of every override's effective window (no visible-range
+   clipping — we want all of history).
+3. For each segment, build a full `dormitories[]` snapshot by applying
+   the active overrides at that segment's start date to the base
+   `dormitories[]` tree (reusing `dormitoriesAt(segmentStart)` from the
+   existing model).
+4. Create one `TimelineConfiguration` per segment, named after the
+   preset that fully covered it (if any) or auto-numbered.
+5. The first segment (covering "the beginning") becomes the initial
+   configuration (`effectiveFrom: null`).
+6. Convert each existing `OverridePreset` into a `ConfigurationTemplate`
+   by applying its entries to the current base — yields one snapshot
+   per preset. (Lossy if the preset only flips a couple attributes; the
+   template will be a full snapshot of "what the base looks like after
+   this preset is applied".)
+7. Wipe `overrides[]` and `presets[]` from persisted state once the
+   migration completes. Keep the empty arrays around for a release as a
+   safety check (so old code reading them sees an empty list rather
+   than `undefined`).
+
+Existing assignments are untouched throughout — same data model on the
+guest-assignment side.
+
+## Things this removes / simplifies
+
+- `ConfigOverride`, `OverridePreset`, `OverrideTarget`, `OverrideAttribute`,
+  `PresetTemplateEntry` types — gone.
+- `dormitoriesAt(date)` becomes O(log N) on the configurations array
+  instead of O(N) over overrides + cascade resolution + deep clone.
+- `useConfigTimelineSegments.ts` becomes a thin wrapper that just maps
+  `configurations[]` to display segments (no boundary collection, no
+  signature math; color is hashed off the configuration id directly).
+- `isBedActiveDuringStay(bedId, arrival, departure)` walks the
+  configurations covering the stay window and checks each one's
+  snapshot — straightforward.
+- `applyPreset` / `revertPresetApplication` / `addOverride` / etc.
+  replaced by `cutAt` / `deleteCut` / `applyTemplateAsCut`.
+- Editing a "Custom" segment: trivially editing that one configuration's
+  snapshot. No mental gymnastics about "which overrides are active
+  here? what does my edit do to them?"
+- `overrideConflict` validation warning becomes "Bed inactive during
+  stay" with the same trigger but resolved from the snapshot, not the
+  override window.
+
+## Things this keeps
+
+- The timeline bar visual: range picker, today line, legend chips,
+  edge-to-edge segments, the leftmost/rightmost edge markers.
+- View Date as the read-side lens in Table View, Timeline View,
+  Print views — already uses `dormitoriesAt(date)`, which still
+  exists.
+- Auto-placement + drop validation integration via the same
+  `isBedActiveDuringStay` API.
+- Layouts deprecation (PR #44). They're already migrated.
+
+## Scope
+
+### In Scope (single PR)
+- Type rename: `ConfigOverride` → `TimelineConfiguration`, `OverridePreset` → `ConfigurationTemplate`.
+- `dormitoryStore` rewrite: `configurations[]` + `configurationTemplates[]` + new operations.
+- Migration from existing `overrides[]` / `presets[]` state.
+- New `useConfigurationTimeline.ts` segment builder (thin).
+- `OverrideTimelineBar.vue` → `ConfigurationTimelineBar.vue` with the new mental model.
+- `PresetsAndOverridesSection.vue` → `ConfigurationsSection.vue` containing the bar + dormitory editor scoped to the selected configuration + templates card.
+- Cut popover (new component, replaces `OneOffOverrideModal`).
+- Save-as-template / apply-template / rename / delete-cut UI.
+- Drop the old `validationStore.overrideConflict` text label → "Bed inactive during stay".
+
+### Out of Scope (deferred)
+- Per-room rows below the macro bar (still useful, still deferred).
+- Drag segment edges to retime cuts (Premiere direct manipulation).
+- Pan / zoom on the timeline.
+- Importing templates between installations.
+
+## Test plan
+
+- **Migration**: a session with 2+ overrides + 1 applied preset migrates
+  to the right configurations + 1 template; visible bar is identical
+  before vs. after.
+- **Cut at today** with no other cuts: produces a second configuration
+  starting today; both share the same starting snapshot; editing the
+  new one doesn't affect the old.
+- **Cut inside a future segment**: splits that segment, two new
+  half-segments both equal to the original at cut time, future half
+  preserves original future state.
+- **Delete cut**: merges into the previous configuration; deleted
+  snapshot is discarded; previous's window extends.
+- **Copy from another configuration**: target gets a deep copy
+  (mutations on the copy don't leak into the source).
+- **Save as template / apply template**: template snapshot is
+  independent of the source after save; applying creates a new cut
+  with the template's snapshot.
+- **isBedActiveDuringStay** correctly returns false when any
+  configuration covering the stay window has the bed / room / dorm
+  inactive.
+- **Existing validation tests pass with the new warning text**.
+
+## Open Questions
+
+1. **Templates equality with current state** — should the templates
+   library auto-detect "this template matches the current selected
+   configuration" and show that next to the template name? (Nice
+   discoverability, not required for v1.)
+2. **Naming defaults** — `"Configuration 3"` is generic. Should we
+   suggest names based on date (`"Jul 4, 2026 →"`) or auto-name to
+   the preset / template that produced the cut? Defer to v1
+   numbering, expose a rename action.
+3. **Bulk delete cuts** — if the operator wants to clear a stretch
+   of the timeline, they can delete cuts one at a time. Worth a
+   "merge all cuts in range" action later, not for v1.
+4. **JSON export/import** — current export is base + overrides + presets;
+   should become configurations + templates. One-line change in
+   `RoomConfigCSV.vue` JSON path.
+
+---
+
+This is a real rework — replacing a substantial chunk of code merged
+in the last day. The win is a much simpler mental model end-to-end:
+the timeline IS the data, every segment is a real Configuration, edits
+go where you'd expect.

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@
           <span v-if="currentBranch && currentBranch !== 'main'" class="branch-indicator">
             ({{ currentBranch }} branch)
           </span>
-          <span class="version-tag">v260614-14:47</span>
+          <span class="version-tag">v260614-22:02</span>
         </h1>
         <button class="tour-btn" @click="startTour" title="Take a guided tour">
           ?
@@ -232,7 +232,7 @@
       </div>
 
       <div class="scrollable-content">
-        <PresetsAndOverridesSection />
+        <ConfigurationsSection />
         <ConfigRoomList
           empty-title="No rooms configured"
           empty-message="Add a dormitory to begin configuring rooms and beds."
@@ -303,7 +303,7 @@ import { HintBanner } from '@/features/hints/components'
 import { useHints } from '@/features/hints/composables/useHints'
 import { useTour } from '@/features/hints/composables/useTour'
 import { GuestList, GuestSearch, ColumnsDropdown } from '@/features/guests/components'
-import { RoomList, ConfigRoomList, LayoutSelector, PresetsAndOverridesSection, LayoutMigrationDialog } from '@/features/dormitories/components'
+import { RoomList, ConfigRoomList, LayoutSelector, ConfigurationsSection, LayoutMigrationDialog } from '@/features/dormitories/components'
 import { RoomConfigCSV, AssignmentCSVExport } from '@/features/csv/components'
 import { AssignmentToolbar, AssignmentStats } from '@/features/assignments/components'
 import { SettingsPanel } from '@/features/settings/components'
@@ -419,6 +419,10 @@ onMounted(() => {
       showLayoutMigration.value = true
     }
   }
+
+  // Cuts-model migration: convert overrides/presets to configurations.
+  // Idempotent — runs once, flips the flag.
+  dormitoryStore.migrateToCutsModel()
 })
 
 const showLayoutMigration = ref(false)

--- a/src/features/dormitories/components/ConfigurationTimelineBar.vue
+++ b/src/features/dormitories/components/ConfigurationTimelineBar.vue
@@ -1,0 +1,308 @@
+<template>
+  <div class="timeline-card">
+    <div class="card-header">
+      <div class="header-left">
+        <h4>Configuration timeline</h4>
+        <span class="header-hint">Click a configuration to edit it. Add a cut to split the timeline.</span>
+      </div>
+      <button class="btn-small" @click="openCut()">+ Cut here…</button>
+    </div>
+
+    <div class="controls">
+      <label class="field">
+        <span class="field-label">From</span>
+        <input type="date" :value="rangeStart" @change="onStartChange" />
+      </label>
+      <label class="field">
+        <span class="field-label">To</span>
+        <input type="date" :value="rangeEnd" @change="onEndChange" />
+      </label>
+      <button class="btn-small" @click="resetRange" title="Reset to current month ± 6 months">Reset range</button>
+    </div>
+
+    <div v-if="rangeStart > rangeEnd" class="warning">
+      "From" must be on or before "To".
+    </div>
+
+    <div v-else class="bar-wrapper">
+      <div class="bar" role="list">
+        <button
+          v-for="(seg, idx) in segments"
+          :key="seg.id"
+          :style="{ flexGrow: seg.durationDays, background: seg.color }"
+          :class="['segment', { 'is-selected': selectedConfigurationId === seg.id }]"
+          role="listitem"
+          :title="segmentTooltip(seg, idx)"
+          @click="selectSegment(seg.id)"
+        >
+          <span v-if="idx === 0" class="edge-marker leading" aria-hidden="true">←</span>
+          <span class="segment-label">{{ seg.name }}</span>
+          <span v-if="idx === segments.length - 1" class="edge-marker trailing" aria-hidden="true">→</span>
+        </button>
+        <div
+          v-if="todayOffset !== null"
+          class="today-indicator"
+          :style="{ left: todayOffset + '%' }"
+          title="Today"
+        />
+      </div>
+      <div class="axis">
+        <span class="axis-tick">{{ formatTick(rangeStart) }}</span>
+        <span class="axis-tick">{{ formatTick(rangeEnd) }}</span>
+      </div>
+    </div>
+
+    <div v-if="legend.length > 1" class="legend">
+      <div v-for="item in legend" :key="item.id" class="legend-chip">
+        <span class="legend-swatch" :style="{ background: item.color }"></span>
+        <span class="legend-label">{{ item.name }}</span>
+      </div>
+    </div>
+
+    <CutPopover :is-open="cutPopoverOpen" :initial-date="cutInitialDate" @close="cutPopoverOpen = false" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch, onMounted } from 'vue'
+import { useDormitoryStore } from '@/stores/dormitoryStore'
+import CutPopover from './CutPopover.vue'
+import type { TimelineConfiguration } from '@/types'
+
+const dormitoryStore = useDormitoryStore()
+
+const RANGE_KEY = 'dormAssignments-configTimelineRange'
+
+const rangeStart = ref('')
+const rangeEnd = ref('')
+const cutPopoverOpen = ref(false)
+const cutInitialDate = ref<string | null>(null)
+
+const selectedConfigurationId = computed(() => dormitoryStore.selectedConfigurationId)
+const configurations = computed(() => dormitoryStore.configurations)
+
+onMounted(() => hydrateRange())
+
+function todayIso(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function defaultRange(): { start: string; end: string } {
+  const now = new Date()
+  const start = new Date(now.getFullYear(), now.getMonth() - 6, 1)
+  const end = new Date(now.getFullYear(), now.getMonth() + 7, 0)
+  return {
+    start: `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}-${String(start.getDate()).padStart(2, '0')}`,
+    end: `${end.getFullYear()}-${String(end.getMonth() + 1).padStart(2, '0')}-${String(end.getDate()).padStart(2, '0')}`,
+  }
+}
+
+function hydrateRange() {
+  const raw = localStorage.getItem(RANGE_KEY)
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw)
+      if (parsed.start && parsed.end && parsed.start <= parsed.end) {
+        rangeStart.value = parsed.start
+        rangeEnd.value = parsed.end
+        return
+      }
+    } catch {
+      // fall through
+    }
+  }
+  const def = defaultRange()
+  rangeStart.value = def.start
+  rangeEnd.value = def.end
+}
+
+watch([rangeStart, rangeEnd], ([s, e]) => {
+  if (!s || !e || s > e) return
+  localStorage.setItem(RANGE_KEY, JSON.stringify({ start: s, end: e }))
+})
+
+function onStartChange(e: Event) { rangeStart.value = (e.target as HTMLInputElement).value }
+function onEndChange(e: Event) { rangeEnd.value = (e.target as HTMLInputElement).value }
+function resetRange() {
+  const def = defaultRange()
+  rangeStart.value = def.start
+  rangeEnd.value = def.end
+}
+
+interface DisplaySegment {
+  id: string
+  name: string
+  start: string
+  end: string
+  durationDays: number
+  color: string
+}
+
+function parseIso(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number)
+  return new Date(y, (m ?? 1) - 1, d ?? 1)
+}
+function addDays(iso: string, days: number): string {
+  const d = parseIso(iso)
+  d.setDate(d.getDate() + days)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+function daysBetween(a: string, b: string): number {
+  const ms = 86400000
+  return Math.round((parseIso(b).getTime() - parseIso(a).getTime()) / ms)
+}
+
+const PALETTE = [
+  '#e5e7eb', // grey — default-y, used for the initial config
+  '#ddd6fe', '#fde68a', '#bbf7d0', '#fbcfe8', '#bae6fd', '#fed7aa', '#c7d2fe', '#fef08a', '#a7f3d0',
+]
+function hashId(id: string): number {
+  let h = 5381
+  for (let i = 0; i < id.length; i++) h = ((h << 5) + h + id.charCodeAt(i)) | 0
+  return Math.abs(h)
+}
+function colorFor(config: TimelineConfiguration): string {
+  if (config.effectiveFrom === null) return PALETTE[0]
+  return PALETTE[(hashId(config.id) % (PALETTE.length - 1)) + 1]
+}
+
+const segments = computed<DisplaySegment[]>(() => {
+  if (!rangeStart.value || !rangeEnd.value || rangeStart.value > rangeEnd.value) return []
+  const cfgs = [...configurations.value].sort((a, b) => {
+    if (a.effectiveFrom === b.effectiveFrom) return 0
+    if (a.effectiveFrom === null) return -1
+    if (b.effectiveFrom === null) return 1
+    return a.effectiveFrom < b.effectiveFrom ? -1 : 1
+  })
+  if (cfgs.length === 0) return []
+
+  const out: DisplaySegment[] = []
+  const rangeEndExclusive = addDays(rangeEnd.value, 1)
+
+  for (let i = 0; i < cfgs.length; i++) {
+    const c = cfgs[i]
+    const next = cfgs[i + 1]
+    const effStart = c.effectiveFrom ?? rangeStart.value
+    const effEndExclusive = next?.effectiveFrom ?? rangeEndExclusive
+
+    // Clip to visible range
+    const segStart = effStart < rangeStart.value ? rangeStart.value : effStart
+    const segEndExclusive = effEndExclusive > rangeEndExclusive ? rangeEndExclusive : effEndExclusive
+    if (segStart >= segEndExclusive) continue
+
+    out.push({
+      id: c.id,
+      name: c.name,
+      start: segStart,
+      end: addDays(segEndExclusive, -1),
+      durationDays: Math.max(1, daysBetween(segStart, segEndExclusive)),
+      color: colorFor(c),
+    })
+  }
+  return out
+})
+
+const legend = computed(() => {
+  const seen = new Set<string>()
+  const out: Array<{ id: string; name: string; color: string }> = []
+  for (const s of segments.value) {
+    if (seen.has(s.id)) continue
+    seen.add(s.id)
+    out.push({ id: s.id, name: s.name, color: s.color })
+  }
+  return out
+})
+
+function selectSegment(id: string) {
+  dormitoryStore.selectConfiguration(id)
+}
+
+function openCut(prefilledDate?: string) {
+  cutInitialDate.value = prefilledDate ?? todayIso()
+  cutPopoverOpen.value = true
+}
+
+function segmentTooltip(seg: DisplaySegment, idx: number): string {
+  const range = `${formatDate(seg.start)} → ${formatDate(seg.end)}`
+  let base = `${seg.name}\n${range}`
+  if (idx === 0) base += `\n← In effect from before ${formatDate(seg.start)}`
+  if (idx === segments.value.length - 1) base += `\n→ Continues beyond ${formatDate(seg.end)}`
+  return base
+}
+
+function formatDate(iso: string): string {
+  const [y, m, d] = iso.split('-').map(Number)
+  if (!y || !m || !d) return iso
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  return `${months[m - 1]} ${d}, ${y}`
+}
+function formatTick(iso: string): string {
+  const [y, m, d] = iso.split('-').map(Number)
+  if (!y || !m || !d) return iso
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  return `${months[m - 1]} ${y}`
+}
+
+const todayOffset = computed<number | null>(() => {
+  const today = todayIso()
+  if (today < rangeStart.value || today > rangeEnd.value) return null
+  const total = daysBetween(rangeStart.value, addDays(rangeEnd.value, 1))
+  if (total <= 0) return null
+  return (daysBetween(rangeStart.value, today) / total) * 100
+})
+</script>
+
+<style scoped lang="scss">
+.timeline-card { background: white; border: 1px solid #e5e7eb; border-radius: 8px; overflow: hidden; }
+.card-header {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 12px 16px; border-bottom: 1px solid #e5e7eb; background: #f9fafb;
+  .header-left { display: flex; flex-direction: column; gap: 2px; }
+  h4 { margin: 0; font-size: 0.95rem; font-weight: 600; color: #374151; }
+  .header-hint { font-size: 0.75rem; color: #6b7280; }
+}
+.controls {
+  display: flex; align-items: flex-end; gap: 12px; padding: 12px 16px;
+  .field { display: flex; flex-direction: column; gap: 4px; }
+  .field-label { font-size: 0.75rem; color: #6b7280; }
+  input[type="date"] { padding: 6px 8px; border: 1px solid #d1d5db; border-radius: 4px; font-size: 0.85rem; }
+}
+.warning {
+  margin: 0 16px 12px; padding: 8px 12px; background: #fee2e2; border: 1px solid #fca5a5;
+  border-radius: 6px; color: #991b1b; font-size: 0.85rem;
+}
+.bar-wrapper { padding: 8px 0 0; }
+.bar {
+  position: relative; display: flex; height: 56px;
+  border-top: 1px solid #d1d5db; border-bottom: 1px solid #d1d5db; overflow: hidden; user-select: none;
+}
+.segment {
+  position: relative; border: none; border-right: 1px solid rgba(0, 0, 0, 0.08);
+  padding: 0 6px; font-size: 0.75rem; font-weight: 500; color: #1f2937;
+  cursor: pointer; display: flex; align-items: center; justify-content: center;
+  min-width: 0; overflow: hidden; transition: filter 0.12s;
+  &:last-child { border-right: none; }
+  &:hover { filter: brightness(0.95); }
+  &.is-selected { filter: brightness(0.85); outline: 2px solid #4f46e5; outline-offset: -2px; }
+}
+.edge-marker { font-size: 0.75rem; color: rgba(0, 0, 0, 0.4); pointer-events: none; flex-shrink: 0;
+  &.leading { margin-right: 4px; } &.trailing { margin-left: 4px; } }
+.segment-label { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; pointer-events: none; }
+.today-indicator {
+  position: absolute; top: -4px; bottom: -4px; width: 2px; background: #ef4444;
+  pointer-events: none; box-shadow: 0 0 0 1px white;
+}
+.axis {
+  display: flex; justify-content: space-between; padding: 4px 16px 8px;
+  font-size: 0.7rem; color: #6b7280;
+}
+.legend { display: flex; flex-wrap: wrap; gap: 8px; padding: 0 16px 12px; }
+.legend-chip { display: inline-flex; align-items: center; gap: 4px; font-size: 0.75rem; color: #374151; }
+.legend-swatch { display: inline-block; width: 14px; height: 14px; border-radius: 3px; border: 1px solid rgba(0,0,0,0.1); }
+.btn-small {
+  padding: 4px 10px; font-size: 0.8rem; border: 1px solid #d1d5db;
+  background: white; border-radius: 4px; cursor: pointer; white-space: nowrap;
+  &:hover { background: #f3f4f6; }
+}
+</style>

--- a/src/features/dormitories/components/ConfigurationsSection.vue
+++ b/src/features/dormitories/components/ConfigurationsSection.vue
@@ -1,0 +1,157 @@
+<template>
+  <section class="configurations">
+    <header class="section-header">
+      <h3>Time-based configurations</h3>
+      <p class="section-hint">
+        The timeline is a sequence of configurations. Add a <strong>cut</strong> to split it; the new segment starts as a copy of the previous one and you edit it independently. Save any configuration as a <strong>template</strong> for reuse.
+      </p>
+    </header>
+
+    <ConfigurationTimelineBar />
+
+    <div v-if="selectedConfiguration" class="editing-bar">
+      <div class="editing-info">
+        <strong>Editing:</strong>
+        <span class="editing-name">{{ selectedConfiguration.name }}</span>
+        <span class="editing-window">{{ formatWindow(selectedConfiguration) }}</span>
+      </div>
+      <div class="editing-actions">
+        <button class="btn-small" @click="rename">Rename</button>
+        <button class="btn-small" @click="saveAsTemplate">Save as template…</button>
+        <button v-if="selectedConfiguration.effectiveFrom !== null" class="btn-small btn-danger" @click="deleteCurrentCut">
+          Delete this cut
+        </button>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h4>Templates</h4>
+        <span class="card-hint">Save any configuration as a template, then paste it as a future cut.</span>
+      </div>
+      <div v-if="templates.length === 0" class="empty">
+        No templates yet. Click <em>Save as template</em> on a configuration above to start.
+      </div>
+      <ul v-else class="template-list">
+        <li v-for="t in templates" :key="t.id" class="template-row">
+          <strong>{{ t.name }}</strong>
+          <span v-if="t.description" class="template-desc">— {{ t.description }}</span>
+          <button class="btn-small" @click="renameTemplate(t.id, t.name)">Rename</button>
+          <button class="btn-small btn-danger" @click="deleteTemplate(t.id)">Delete</button>
+        </li>
+      </ul>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useDormitoryStore } from '@/stores/dormitoryStore'
+import ConfigurationTimelineBar from './ConfigurationTimelineBar.vue'
+import type { TimelineConfiguration } from '@/types'
+
+const dormitoryStore = useDormitoryStore()
+
+const templates = computed(() => dormitoryStore.configurationTemplates)
+const selectedConfiguration = computed<TimelineConfiguration | null>(() => {
+  const id = dormitoryStore.selectedConfigurationId
+  if (!id) return null
+  return dormitoryStore.configurations.find(c => c.id === id) ?? null
+})
+
+function rename() {
+  if (!selectedConfiguration.value) return
+  const next = window.prompt('Rename configuration:', selectedConfiguration.value.name)
+  if (!next?.trim()) return
+  dormitoryStore.renameConfiguration(selectedConfiguration.value.id, next.trim())
+}
+
+function saveAsTemplate() {
+  if (!selectedConfiguration.value) return
+  const name = window.prompt('Save as template — name:', selectedConfiguration.value.name)
+  if (!name?.trim()) return
+  dormitoryStore.saveConfigurationAsTemplate(selectedConfiguration.value.id, name.trim())
+}
+
+function deleteCurrentCut() {
+  if (!selectedConfiguration.value) return
+  const c = selectedConfiguration.value
+  if (!window.confirm(`Delete the cut for "${c.name}"? Its snapshot is discarded; the previous configuration's window extends to the next cut.`)) return
+  dormitoryStore.deleteCut(c.id)
+}
+
+function renameTemplate(id: string, currentName: string) {
+  const next = window.prompt('Rename template:', currentName)
+  if (!next?.trim()) return
+  dormitoryStore.renameConfigurationTemplate(id, next.trim())
+}
+
+function deleteTemplate(id: string) {
+  if (!window.confirm('Delete this template?')) return
+  dormitoryStore.deleteConfigurationTemplate(id)
+}
+
+function formatWindow(c: TimelineConfiguration): string {
+  const cfgs = [...dormitoryStore.configurations].sort((a, b) => {
+    if (a.effectiveFrom === b.effectiveFrom) return 0
+    if (a.effectiveFrom === null) return -1
+    if (b.effectiveFrom === null) return 1
+    return a.effectiveFrom < b.effectiveFrom ? -1 : 1
+  })
+  const idx = cfgs.findIndex(x => x.id === c.id)
+  const next = cfgs[idx + 1]
+  const start = c.effectiveFrom ? formatDate(c.effectiveFrom) : 'forever before'
+  const end = next?.effectiveFrom ? formatDate(addDays(next.effectiveFrom, -1)) : 'forever after'
+  return `(${start} → ${end})`
+}
+
+function formatDate(iso: string): string {
+  const [y, m, d] = iso.split('-').map(Number)
+  if (!y || !m || !d) return iso
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  return `${months[m - 1]} ${d}, ${y}`
+}
+function addDays(iso: string, days: number): string {
+  const [y, m, d] = iso.split('-').map(Number)
+  const dt = new Date(y, m - 1, d)
+  dt.setDate(dt.getDate() + days)
+  return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`
+}
+</script>
+
+<style scoped lang="scss">
+.configurations { padding: 0 16px 24px; display: flex; flex-direction: column; gap: 16px; }
+.section-header {
+  h3 { margin: 0 0 4px 0; font-size: 1.125rem; font-weight: 600; color: #1f2937; }
+  .section-hint { margin: 0; font-size: 0.85rem; color: #6b7280; line-height: 1.4; }
+}
+.editing-bar {
+  display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 10px;
+  padding: 8px 12px; background: #eef2ff; border: 1px solid #c7d2fe; border-radius: 6px;
+  .editing-info { display: flex; align-items: baseline; gap: 6px; font-size: 0.85rem; }
+  .editing-name { color: #4f46e5; font-weight: 500; }
+  .editing-window { color: #6b7280; font-size: 0.75rem; }
+  .editing-actions { display: flex; gap: 6px; }
+}
+.card { background: white; border: 1px solid #e5e7eb; border-radius: 8px; overflow: hidden; }
+.card-header {
+  padding: 12px 16px; border-bottom: 1px solid #e5e7eb; background: #f9fafb;
+  display: flex; flex-direction: column; gap: 2px;
+  h4 { margin: 0; font-size: 0.95rem; font-weight: 600; color: #374151; }
+  .card-hint { font-size: 0.75rem; color: #6b7280; }
+}
+.empty { padding: 16px; font-size: 0.85rem; color: #6b7280; text-align: center; }
+.template-list { list-style: none; padding: 0; margin: 0; }
+.template-row {
+  display: flex; align-items: center; gap: 10px; padding: 8px 16px;
+  border-bottom: 1px solid #f3f4f6; font-size: 0.85rem;
+  &:last-child { border-bottom: none; }
+  .template-desc { color: #6b7280; flex: 1; }
+}
+.btn-small {
+  padding: 4px 10px; font-size: 0.8rem; border: 1px solid #d1d5db;
+  background: white; border-radius: 4px; cursor: pointer; white-space: nowrap;
+  &:hover { background: #f3f4f6; }
+  &.btn-danger { color: #b91c1c; border-color: #fca5a5; &:hover { background: #fee2e2; } }
+}
+</style>

--- a/src/features/dormitories/components/CutPopover.vue
+++ b/src/features/dormitories/components/CutPopover.vue
@@ -1,0 +1,166 @@
+<template>
+  <Modal :model-value="isOpen" title="Add a cut" max-width="520px" @update:model-value="(v) => !v && cancel()">
+    <div class="form">
+      <p class="hint">
+        A cut splits the timeline. The new segment starts on the date you pick and runs forward until the next cut (or forever). It begins as a copy of an existing configuration — you can edit it independently.
+      </p>
+
+      <label class="field">
+        <span class="field-label">Date</span>
+        <input type="date" v-model="effectiveFrom" />
+      </label>
+
+      <label class="field">
+        <span class="field-label">Name (optional)</span>
+        <input type="text" v-model="name" placeholder="e.g. Women's Retreat" />
+      </label>
+
+      <div class="field">
+        <span class="field-label">Start from</span>
+        <div class="source-options">
+          <label class="source-option">
+            <input type="radio" v-model="source" value="current" />
+            <span>Empty copy of the current configuration on that date</span>
+          </label>
+          <label class="source-option">
+            <input type="radio" v-model="source" value="copyFrom" :disabled="otherConfigurations.length === 0" />
+            <span>Copy from another configuration on the timeline</span>
+          </label>
+          <select v-if="source === 'copyFrom'" v-model="copyFromId" class="sub-select">
+            <option value="" disabled>Pick a configuration…</option>
+            <option v-for="c in otherConfigurations" :key="c.id" :value="c.id">
+              {{ c.name }} <span v-if="c.effectiveFrom">({{ formatDate(c.effectiveFrom) }})</span>
+            </option>
+          </select>
+
+          <label class="source-option">
+            <input type="radio" v-model="source" value="template" :disabled="templates.length === 0" />
+            <span>Use a template</span>
+          </label>
+          <select v-if="source === 'template'" v-model="templateId" class="sub-select">
+            <option value="" disabled>Pick a template…</option>
+            <option v-for="t in templates" :key="t.id" :value="t.id">{{ t.name }}</option>
+          </select>
+        </div>
+      </div>
+
+      <div v-if="dateError" class="warning">{{ dateError }}</div>
+    </div>
+
+    <template #footer>
+      <button class="btn" @click="cancel">Cancel</button>
+      <button class="btn btn-primary" :disabled="!canCommit" @click="commit">Add cut</button>
+    </template>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import Modal from '@/shared/components/Modal.vue'
+import { useDormitoryStore } from '@/stores/dormitoryStore'
+
+interface Props {
+  isOpen: boolean
+  initialDate?: string | null
+}
+
+const props = withDefaults(defineProps<Props>(), { initialDate: null })
+const emit = defineEmits<{ close: [] }>()
+
+const dormitoryStore = useDormitoryStore()
+
+const effectiveFrom = ref('')
+const name = ref('')
+const source = ref<'current' | 'copyFrom' | 'template'>('current')
+const copyFromId = ref('')
+const templateId = ref('')
+
+watch(
+  () => props.isOpen,
+  open => {
+    if (!open) return
+    effectiveFrom.value = props.initialDate ?? todayIso()
+    name.value = ''
+    source.value = 'current'
+    copyFromId.value = ''
+    templateId.value = ''
+  },
+  { immediate: true }
+)
+
+function todayIso(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+const otherConfigurations = computed(() => {
+  return dormitoryStore.configurations.filter(c => c.effectiveFrom !== effectiveFrom.value)
+})
+const templates = computed(() => dormitoryStore.configurationTemplates)
+
+const dateError = computed<string | null>(() => {
+  if (!effectiveFrom.value) return 'Pick a date.'
+  const existing = dormitoryStore.configurations.find(c => c.effectiveFrom === effectiveFrom.value)
+  if (existing) return `A cut already exists on ${formatDate(effectiveFrom.value)}.`
+  return null
+})
+
+const canCommit = computed(() => {
+  if (dateError.value) return false
+  if (source.value === 'copyFrom' && !copyFromId.value) return false
+  if (source.value === 'template' && !templateId.value) return false
+  return true
+})
+
+function commit() {
+  if (!canCommit.value) return
+  const opts: { name?: string; copyFrom?: string; templateId?: string } = {}
+  if (name.value.trim()) opts.name = name.value.trim()
+  if (source.value === 'copyFrom') opts.copyFrom = copyFromId.value
+  if (source.value === 'template') opts.templateId = templateId.value
+  const created = dormitoryStore.cutAt(effectiveFrom.value, opts)
+  if (created) {
+    // Immediately select the new segment so the operator can edit it.
+    dormitoryStore.selectConfiguration(created.id)
+  }
+  emit('close')
+}
+
+function cancel() {
+  emit('close')
+}
+
+function formatDate(iso: string): string {
+  const [y, m, d] = iso.split('-').map(Number)
+  if (!y || !m || !d) return iso
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  return `${months[m - 1]} ${d}, ${y}`
+}
+</script>
+
+<style scoped lang="scss">
+.form { display: flex; flex-direction: column; gap: 14px; }
+.hint { margin: 0; font-size: 0.85rem; color: #6b7280; line-height: 1.4; }
+.field { display: flex; flex-direction: column; gap: 6px; }
+.field-label { font-size: 0.8rem; font-weight: 500; color: #374151; }
+input[type="text"], input[type="date"], select.sub-select {
+  padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 4px; font-size: 0.9rem;
+}
+.source-options {
+  display: flex; flex-direction: column; gap: 6px;
+  .source-option {
+    display: flex; align-items: center; gap: 8px; font-size: 0.85rem; color: #374151;
+    input[type="radio"]:disabled + span { color: #9ca3af; }
+  }
+  .sub-select { margin-left: 24px; max-width: 320px; }
+}
+.warning {
+  padding: 8px 12px; background: #fee2e2; border: 1px solid #fca5a5;
+  border-radius: 6px; color: #991b1b; font-size: 0.85rem;
+}
+.btn { padding: 8px 16px; border: 1px solid #d1d5db; background: white; border-radius: 4px; font-size: 0.9rem; cursor: pointer; }
+.btn:hover { background: #f3f4f6; }
+.btn.btn-primary { background: #4f46e5; color: white; border-color: #4f46e5; }
+.btn.btn-primary:hover { background: #4338ca; }
+.btn.btn-primary:disabled { background: #c7d2fe; cursor: not-allowed; }
+</style>

--- a/src/features/dormitories/components/index.ts
+++ b/src/features/dormitories/components/index.ts
@@ -27,3 +27,8 @@ export { default as OverrideTimelineBar } from './OverrideTimelineBar.vue'
 
 // Layout deprecation
 export { default as LayoutMigrationDialog } from './LayoutMigrationDialog.vue'
+
+// Configuration cuts (current model)
+export { default as ConfigurationsSection } from './ConfigurationsSection.vue'
+export { default as ConfigurationTimelineBar } from './ConfigurationTimelineBar.vue'
+export { default as CutPopover } from './CutPopover.vue'

--- a/src/shared/composables/useDropValidation.test.ts
+++ b/src/shared/composables/useDropValidation.test.ts
@@ -83,7 +83,7 @@ describe('useDropValidation — override-aware', () => {
     const { validateDrop } = useDropValidation()
     const result = validateDrop(guest.id, 'B01')
     expect(result.isValid).toBe(false)
-    expect(result.reason).toMatch(/inactive|override/i)
+    expect(result.reason).toMatch(/inactive/i)
   })
 
   it('accepts a drop when the stay falls outside the override window', () => {

--- a/src/shared/composables/useDropValidation.ts
+++ b/src/shared/composables/useDropValidation.ts
@@ -34,7 +34,7 @@ export function useDropValidation() {
     // Bed must be active during the guest's entire stay — covers
     // time-based overrides (dorm closed, room closed, bed closed).
     if (!dormitoryStore.isBedActiveDuringStay(bedId, guest.arrival, guest.departure)) {
-      return { isValid: false, reason: 'Bed inactive during stay (override active)' }
+      return { isValid: false, reason: 'Bed inactive during stay' }
     }
 
     return validateGuestBedCompatibility(guest, bed, room)

--- a/src/stores/dormitoryStore.cuts.test.ts
+++ b/src/stores/dormitoryStore.cuts.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for the Configuration Cuts model (specs/ConfigurationCuts.md).
+ *
+ * Covers: cutAt with each source mode, deleteCut + initial-config
+ * refusal, the migration path from override+preset state to
+ * configurations+templates, and dormitoriesAt resolving via the
+ * configurations array once migrated.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useDormitoryStore } from './dormitoryStore'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { store = {} },
+    key: () => null,
+    length: 0,
+  }
+})()
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+if (typeof globalThis.crypto === 'undefined') {
+  ;(globalThis as { crypto: Crypto }).crypto = {
+    randomUUID: () => Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`,
+  } as Crypto
+} else if (typeof globalThis.crypto.randomUUID !== 'function') {
+  globalThis.crypto.randomUUID = () =>
+    Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`
+}
+
+function seedBase() {
+  const dorm = useDormitoryStore()
+  dorm.importDormitories([
+    {
+      dormitoryName: 'Maple Hall',
+      active: true,
+      rooms: [
+        {
+          roomName: 'Room A',
+          roomGender: 'M',
+          active: true,
+          beds: [{ bedId: 'MA1', bedType: 'single', position: 1, assignments: [] }],
+        },
+      ],
+    },
+  ])
+  return dorm
+}
+
+describe('cuts: migration from override-free initial state', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('seeds a single initial configuration when there are no overrides', () => {
+    const dorm = seedBase()
+    dorm.migrateToCutsModel()
+    expect(dorm.configurations.length).toBe(1)
+    expect(dorm.configurations[0].effectiveFrom).toBeNull()
+    expect(dorm.configurations[0].name).toBe('Default')
+    expect(dorm.cutsModelMigrationComplete).toBe(true)
+  })
+
+  it('is idempotent — re-running does not duplicate configurations', () => {
+    const dorm = seedBase()
+    dorm.migrateToCutsModel()
+    const after1 = dorm.configurations.length
+    dorm.migrateToCutsModel()
+    expect(dorm.configurations.length).toBe(after1)
+  })
+})
+
+describe('cuts: migration from overrides + presets', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('creates a configuration per segment boundary and clears overrides', () => {
+    const dorm = seedBase()
+    // One open-ended override + one bounded one → 2 boundaries → 3 segments
+    dorm.addOverride({
+      target: { kind: 'dormitory', dormitoryName: 'Maple Hall' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-04',
+      effectiveTo: '2026-07-11',
+    })
+    dorm.addOverride({
+      target: { kind: 'bed', bedId: 'MA1' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-08-12',
+      effectiveTo: null,
+    })
+
+    dorm.migrateToCutsModel()
+    // Initial + 3 cut points (Jul 4, Jul 12, Aug 12)
+    expect(dorm.configurations.length).toBe(4)
+    expect(dorm.configurations[0].effectiveFrom).toBeNull()
+    expect(dorm.configurations[1].effectiveFrom).toBe('2026-07-04')
+    expect(dorm.configurations[2].effectiveFrom).toBe('2026-07-12')
+    expect(dorm.configurations[3].effectiveFrom).toBe('2026-08-12')
+    expect(dorm.overrides.length).toBe(0)
+    expect(dorm.cutsModelMigrationComplete).toBe(true)
+  })
+
+  it('snapshots each segment with the right effective state', () => {
+    const dorm = seedBase()
+    dorm.addOverride({
+      target: { kind: 'dormitory', dormitoryName: 'Maple Hall' },
+      change: { attr: 'active', value: false },
+      effectiveFrom: '2026-07-04',
+      effectiveTo: '2026-07-11',
+    })
+    dorm.migrateToCutsModel()
+
+    // Segment covering Jul 6 should show Maple Hall closed.
+    const at = dorm.configurationCovering('2026-07-06')
+    expect(at?.dormitories[0].dormitoryName).toBe('Maple Hall')
+    expect(at?.dormitories[0].active).toBe(false)
+
+    // Segment after the window should show Maple Hall open again.
+    const after = dorm.configurationCovering('2026-08-01')
+    expect(after?.dormitories[0].active).toBe(true)
+  })
+
+  it('converts each preset into a template', () => {
+    const dorm = seedBase()
+    dorm.addPreset({
+      name: 'Closed for cleaning',
+      entries: [
+        {
+          target: { kind: 'dormitory', dormitoryName: 'Maple Hall' },
+          change: { attr: 'active', value: false },
+        },
+      ],
+    })
+    dorm.migrateToCutsModel()
+    expect(dorm.configurationTemplates.length).toBe(1)
+    expect(dorm.configurationTemplates[0].name).toBe('Closed for cleaning')
+    expect(dorm.configurationTemplates[0].dormitories[0].active).toBe(false)
+  })
+})
+
+describe('cuts: cutAt', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('inserts a new configuration starting at the cut date, copied from the covering config', () => {
+    const dorm = seedBase()
+    dorm.migrateToCutsModel()
+    const created = dorm.cutAt('2026-07-04')
+    expect(created).not.toBeNull()
+    expect(dorm.configurations.length).toBe(2)
+    expect(created!.effectiveFrom).toBe('2026-07-04')
+    // Copied from initial → same snapshot (independent object)
+    expect(created!.dormitories[0].dormitoryName).toBe('Maple Hall')
+    expect(created!.dormitories).not.toBe(dorm.configurations[0].dormitories)
+  })
+
+  it('refuses to insert a duplicate cut date', () => {
+    const dorm = seedBase()
+    dorm.migrateToCutsModel()
+    dorm.cutAt('2026-07-04')
+    const second = dorm.cutAt('2026-07-04')
+    expect(second).toBeNull()
+    expect(dorm.configurations.length).toBe(2)
+  })
+
+  it('copyFrom uses another configuration as the source', () => {
+    const dorm = seedBase()
+    dorm.migrateToCutsModel()
+    const first = dorm.cutAt('2026-07-04', { name: 'Closed' })!
+    // Edit first to mark Maple Hall closed.
+    first.dormitories[0].active = false
+
+    const second = dorm.cutAt('2026-09-01', { copyFrom: first.id })!
+    expect(second.dormitories[0].active).toBe(false)
+    // Mutations on second don't leak into first.
+    second.dormitories[0].active = true
+    expect(first.dormitories[0].active).toBe(false)
+  })
+
+  it('templateId pastes a template snapshot', () => {
+    const dorm = seedBase()
+    dorm.migrateToCutsModel()
+    const tpl = dorm.saveConfigurationAsTemplate(dorm.configurations[0].id, 'Template')
+    expect(tpl).not.toBeNull()
+    // Manually edit the template's snapshot.
+    tpl!.dormitories[0].active = false
+
+    const cut = dorm.cutAt('2026-08-12', { templateId: tpl!.id })!
+    expect(cut.dormitories[0].active).toBe(false)
+  })
+})
+
+describe('cuts: deleteCut', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('refuses to delete the initial (effectiveFrom: null) configuration', () => {
+    const dorm = seedBase()
+    dorm.migrateToCutsModel()
+    const initial = dorm.configurations[0]
+    expect(dorm.deleteCut(initial.id)).toBe(false)
+    expect(dorm.configurations.length).toBe(1)
+  })
+
+  it('deletes a non-initial cut and merges its window into the previous one', () => {
+    const dorm = seedBase()
+    dorm.migrateToCutsModel()
+    dorm.cutAt('2026-07-04')
+    expect(dorm.configurations.length).toBe(2)
+    const second = dorm.configurations[1]
+    expect(dorm.deleteCut(second.id)).toBe(true)
+    expect(dorm.configurations.length).toBe(1)
+    expect(dorm.configurations[0].effectiveFrom).toBeNull()
+  })
+})
+
+describe('cuts: dormitoriesAt routes through configurations after migration', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  it('returns the matching configuration\'s snapshot', () => {
+    const dorm = seedBase()
+    dorm.migrateToCutsModel()
+    const cut = dorm.cutAt('2026-07-04', { name: 'Cleaning' })!
+    cut.dormitories[0].active = false
+
+    const beforeCut = dorm.dormitoriesAt('2026-07-03')
+    const inCut = dorm.dormitoriesAt('2026-07-05')
+    expect(beforeCut[0].active).toBe(true)
+    expect(inCut[0].active).toBe(false)
+  })
+})

--- a/src/stores/dormitoryStore.ts
+++ b/src/stores/dormitoryStore.ts
@@ -19,6 +19,8 @@ import type {
   OverrideAttribute,
   PresetTemplateEntry,
   RoomGender,
+  TimelineConfiguration,
+  ConfigurationTemplate,
 } from '@/types'
 import { DEFAULT_COLORS } from '@/types'
 import { parseLocalDate } from '@/shared/composables/useUtils'
@@ -62,6 +64,24 @@ export const useDormitoryStore = defineStore(
      * during initialization so no dialog appears.
      */
     const layoutMigrationComplete = ref<boolean>(false)
+
+    /**
+     * Configuration-cuts model (`specs/ConfigurationCuts.md`).
+     *
+     * `configurations` is a sorted array (by `effectiveFrom` ascending,
+     * `null` first). There is always exactly one configuration with
+     * `effectiveFrom === null` — the initial one covering "from the
+     * start of time" up to the next cut.
+     *
+     * `selectedConfigurationId` is the editing target: which
+     * configuration the dormitory editor in Configuration tab edits.
+     * Defaults to the configuration covering today.
+     */
+    const configurations = ref<TimelineConfiguration[]>([])
+    const configurationTemplates = ref<ConfigurationTemplate[]>([])
+    const selectedConfigurationId = ref<string | null>(null)
+    /** Flipped true after migrating from overrides/presets to configurations. */
+    const cutsModelMigrationComplete = ref<boolean>(false)
 
     // Internal flag to suppress auto-save during layout switch
     let _suppressAutoSave = false
@@ -615,8 +635,47 @@ export const useDormitoryStore = defineStore(
      * Pass `date === null` to skip override resolution and return the raw
      * base tree (useful for editing the base config in Room Configuration).
      */
+    /**
+     * Pick the configuration covering `date`. Configurations are kept
+     * sorted by `effectiveFrom` (with the `null` initial config first),
+     * so the covering config is the latest one whose `effectiveFrom <=
+     * date`. `date === null` → today.
+     */
+    function configurationCovering(date: string | null): TimelineConfiguration | null {
+      const list = configurations.value
+      if (list.length === 0) return null
+      const probe = date ?? todayIso()
+      let match: TimelineConfiguration | null = null
+      for (const c of list) {
+        if (c.effectiveFrom === null) {
+          match = c
+        } else if (c.effectiveFrom <= probe) {
+          match = c
+        } else {
+          break
+        }
+      }
+      return match
+    }
+
+    function todayIso(): string {
+      const d = new Date()
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+    }
+
     const dormitoriesAt = computed(() => {
       return (date: string | null): Dormitory[] => {
+        // New cuts model: each date resolves to the configuration whose
+        // window covers it. Once we've migrated, configurations is the
+        // sole source of truth.
+        if (configurations.value.length > 0) {
+          const c = configurationCovering(date)
+          if (c) return c.dormitories
+        }
+
+        // Pre-migration / legacy fallback to the override-resolution
+        // path. Kept so the migration code itself can call
+        // `dormitoriesAt(start)` on each segment boundary to snapshot.
         if (!date) return dormitories.value
 
         const active = overrides.value.filter(o => isOverrideActiveOn(o, date))
@@ -920,6 +979,379 @@ export const useDormitoryStore = defineStore(
       return before - overrides.value.length
     }
 
+    // --- Configuration Cuts (specs/ConfigurationCuts.md) ---
+
+    function _cloneDormitories(tree: Dormitory[]): Dormitory[] {
+      return structuredClone(toRaw(tree))
+    }
+
+    /**
+     * Keep `configurations` sorted by `effectiveFrom` ascending, with
+     * the null (initial) one first. Called after every mutation.
+     */
+    function _sortConfigurations() {
+      configurations.value.sort((a, b) => {
+        if (a.effectiveFrom === b.effectiveFrom) return 0
+        if (a.effectiveFrom === null) return -1
+        if (b.effectiveFrom === null) return 1
+        return a.effectiveFrom < b.effectiveFrom ? -1 : 1
+      })
+    }
+
+    interface CutOptions {
+      /** Optional name; auto-numbered if omitted. */
+      name?: string
+      /**
+       * Source for the new segment's snapshot. Default: clone the
+       * configuration covering `date`. Pass another configuration id
+       * to copy from elsewhere on the timeline, or a templateId to
+       * paste a template.
+       */
+      copyFrom?: string
+      templateId?: string
+    }
+
+    /**
+     * Insert a cut at `date`. The new TimelineConfiguration starts at
+     * that date and is a deep copy of either (a) the configuration
+     * covering `date`, (b) another configuration if `copyFrom` is set,
+     * or (c) a template if `templateId` is set. Returns the new
+     * configuration (or null if `date` already has a cut).
+     */
+    function cutAt(date: string, options: CutOptions = {}): TimelineConfiguration | null {
+      if (!date) return null
+      const existing = configurations.value.find(c => c.effectiveFrom === date)
+      if (existing) return null
+
+      let source: Dormitory[] | null = null
+      if (options.templateId) {
+        const tpl = configurationTemplates.value.find(t => t.id === options.templateId)
+        if (tpl) source = _cloneDormitories(tpl.dormitories)
+      } else if (options.copyFrom) {
+        const src = configurations.value.find(c => c.id === options.copyFrom)
+        if (src) source = _cloneDormitories(src.dormitories)
+      } else {
+        const covering = configurationCovering(date)
+        if (covering) source = _cloneDormitories(covering.dormitories)
+      }
+      if (!source) source = _cloneDormitories(dormitories.value)
+
+      const now = new Date().toISOString()
+      const config: TimelineConfiguration = {
+        id: crypto.randomUUID(),
+        effectiveFrom: date,
+        name: options.name?.trim() || `Configuration ${configurations.value.length + 1}`,
+        dormitories: source,
+        createdAt: now,
+        updatedAt: now,
+      }
+      configurations.value.push(config)
+      _sortConfigurations()
+      return config
+    }
+
+    /**
+     * Remove a non-initial cut. The previous configuration's window
+     * naturally extends to the next cut. Returns true on success,
+     * false if the configuration is the initial one (refused) or
+     * doesn't exist.
+     */
+    function deleteCut(configurationId: string): boolean {
+      const idx = configurations.value.findIndex(c => c.id === configurationId)
+      if (idx === -1) return false
+      const target = configurations.value[idx]
+      if (target.effectiveFrom === null) return false
+      configurations.value.splice(idx, 1)
+      // If the deleted one was selected, fall back to today's covering.
+      if (selectedConfigurationId.value === configurationId) {
+        const fallback = configurationCovering(null)
+        selectedConfigurationId.value = fallback?.id ?? null
+      }
+      return true
+    }
+
+    /** Replace a configuration's snapshot with a new tree. */
+    function updateConfigurationDormitories(configurationId: string, tree: Dormitory[]): boolean {
+      const c = configurations.value.find(x => x.id === configurationId)
+      if (!c) return false
+      c.dormitories = _cloneDormitories(tree)
+      c.updatedAt = new Date().toISOString()
+      return true
+    }
+
+    function renameConfiguration(configurationId: string, name: string): boolean {
+      const c = configurations.value.find(x => x.id === configurationId)
+      if (!c) return false
+      c.name = name.trim() || c.name
+      c.updatedAt = new Date().toISOString()
+      return true
+    }
+
+    function saveConfigurationAsTemplate(configurationId: string, name: string, description?: string): ConfigurationTemplate | null {
+      const c = configurations.value.find(x => x.id === configurationId)
+      if (!c) return null
+      const tpl: ConfigurationTemplate = {
+        id: crypto.randomUUID(),
+        name: name.trim() || c.name,
+        description,
+        dormitories: _cloneDormitories(c.dormitories),
+        createdAt: new Date().toISOString(),
+      }
+      configurationTemplates.value.push(tpl)
+      return tpl
+    }
+
+    function deleteConfigurationTemplate(templateId: string): boolean {
+      const idx = configurationTemplates.value.findIndex(t => t.id === templateId)
+      if (idx === -1) return false
+      configurationTemplates.value.splice(idx, 1)
+      return true
+    }
+
+    function renameConfigurationTemplate(templateId: string, name: string): boolean {
+      const t = configurationTemplates.value.find(x => x.id === templateId)
+      if (!t) return false
+      t.name = name.trim() || t.name
+      return true
+    }
+
+    /**
+     * The configuration whose window covers today. Read-only helper —
+     * Configuration tab uses this as the default editing target.
+     */
+    const currentConfiguration = computed<TimelineConfiguration | null>(() => {
+      return configurationCovering(null)
+    })
+
+    /** Set the editing target by id. No-op if id is unknown. */
+    function selectConfiguration(configurationId: string | null) {
+      if (configurationId === null) {
+        selectedConfigurationId.value = null
+        return
+      }
+      if (configurations.value.find(c => c.id === configurationId)) {
+        selectedConfigurationId.value = configurationId
+      }
+    }
+
+    /**
+     * One-way migration from the override / preset model
+     * (TimeBasedRoomConfig spec) to the cuts model
+     * (ConfigurationCuts spec). Idempotent — runs once, marked complete.
+     *
+     * Steps:
+     *   1. Compute the segment boundaries from existing overrides.
+     *   2. For each segment, snapshot the effective config at the
+     *      segment's start via the legacy `dormitoriesAt`.
+     *   3. The "earliest" segment becomes the initial configuration
+     *      (`effectiveFrom: null`).
+     *   4. Each preset becomes a ConfigurationTemplate (snapshot of base
+     *      after applying that preset's entries).
+     *   5. Clear `overrides` and `presets`; flip the migration flag.
+     *
+     * If `configurations` is already non-empty, this just flips the
+     * flag without touching anything. If both `overrides` and `presets`
+     * are empty, a single initial configuration is created from the
+     * current `dormitories` tree.
+     */
+    function migrateToCutsModel() {
+      if (cutsModelMigrationComplete.value) return
+      if (configurations.value.length > 0) {
+        cutsModelMigrationComplete.value = true
+        return
+      }
+
+      // Collect all override boundary dates.
+      const boundarySet = new Set<string>()
+      for (const o of overrides.value) {
+        boundarySet.add(o.effectiveFrom)
+        if (o.effectiveTo !== null) {
+          // The day AFTER effectiveTo is when the override flips off.
+          const d = parseLocalDate(o.effectiveTo)
+          if (!isNaN(d.getTime())) {
+            d.setDate(d.getDate() + 1)
+            boundarySet.add(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`)
+          }
+        }
+      }
+      const boundaries = [...boundarySet].sort()
+      const now = new Date().toISOString()
+
+      // First configuration: effectiveFrom = null = initial.
+      const initial: TimelineConfiguration = {
+        id: crypto.randomUUID(),
+        effectiveFrom: null,
+        name: 'Default',
+        // Snapshot the "before any overrides" state = the raw base.
+        dormitories: _cloneDormitories(dormitories.value),
+        createdAt: now,
+        updatedAt: now,
+      }
+      configurations.value.push(initial)
+
+      // For each boundary, snapshot the effective config at that date.
+      for (let i = 0; i < boundaries.length; i++) {
+        const start = boundaries[i]
+        // _resolveLegacy uses the OLD override path because configurations
+        // is non-empty by now and dormitoriesAt would short-circuit.
+        const snapshot = _resolveLegacyDormitoriesAt(start)
+        // Name from the preset that fully covers this segment, if any.
+        const activeAtStart = overrides.value.filter(o => isOverrideActiveOn(o, start))
+        let name = `Configuration ${i + 2}`
+        const presetCounts = new Map<string, number>()
+        for (const o of activeAtStart) {
+          if (o.presetId) {
+            presetCounts.set(o.presetId, (presetCounts.get(o.presetId) ?? 0) + 1)
+          }
+        }
+        if (presetCounts.size === 1) {
+          const onlyId = [...presetCounts.keys()][0]
+          const preset = presets.value.find(p => p.id === onlyId)
+          if (preset) name = preset.name
+        } else if (presetCounts.size === 0 && activeAtStart.length === 0) {
+          name = 'Default'
+        }
+        configurations.value.push({
+          id: crypto.randomUUID(),
+          effectiveFrom: start,
+          name,
+          dormitories: snapshot,
+          createdAt: now,
+          updatedAt: now,
+        })
+      }
+
+      // Each preset → ConfigurationTemplate. Apply the preset's entries
+      // to the base in-memory and snapshot the result.
+      for (const preset of presets.value) {
+        const synthetic: ConfigOverride[] = preset.entries.map((e, idx) => ({
+          id: `_migrate_${preset.id}_${idx}`,
+          target: e.target,
+          change: e.change,
+          effectiveFrom: '1900-01-01',
+          effectiveTo: null,
+          presetId: preset.id,
+          applicationId: null,
+          createdAt: now,
+        }))
+        const baseDorms = _cloneDormitories(dormitories.value)
+        const snapshot = _applyOverridesToTree(baseDorms, synthetic, '1900-01-02')
+        configurationTemplates.value.push({
+          id: crypto.randomUUID(),
+          name: preset.name,
+          description: preset.description,
+          dormitories: snapshot,
+          createdAt: now,
+        })
+      }
+
+      _sortConfigurations()
+      // Default editing target = today's covering config.
+      selectedConfigurationId.value = configurationCovering(null)?.id ?? initial.id
+
+      // Clear legacy state (kept in the persisted schema for one release
+      // for rollback; emptied here to prevent double-counting).
+      overrides.value = []
+      presets.value = []
+      cutsModelMigrationComplete.value = true
+    }
+
+    /** Same logic as `dormitoriesAt` was before the cuts-model branch. */
+    function _resolveLegacyDormitoriesAt(date: string): Dormitory[] {
+      const active = overrides.value.filter(o => isOverrideActiveOn(o, date))
+      if (active.length === 0) return _cloneDormitories(dormitories.value)
+      return _applyOverridesToTree(_cloneDormitories(dormitories.value), active, date)
+    }
+
+    /** Lifted from the original cascade logic so the migration can reuse it. */
+    function _applyOverridesToTree(tree: Dormitory[], active: ConfigOverride[], _date: string): Dormitory[] {
+      const sorted = [...active].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      const dormActiveMap = new Map<string, boolean>()
+      const roomActiveMap = new Map<string, boolean>()
+      const roomGenderMap = new Map<string, RoomGender>()
+      const bedActiveMap = new Map<string, boolean>()
+      const roomKey = (d: string, r: string) => `${d} ${r}`
+      for (const o of sorted) {
+        if (o.target.kind === 'dormitory' && o.change.attr === 'active') {
+          if (!dormActiveMap.has(o.target.dormitoryName)) dormActiveMap.set(o.target.dormitoryName, o.change.value)
+        } else if (o.target.kind === 'room' && o.change.attr === 'active') {
+          const k = roomKey(o.target.dormitoryName, o.target.roomName)
+          if (!roomActiveMap.has(k)) roomActiveMap.set(k, o.change.value)
+        } else if (o.target.kind === 'room' && o.change.attr === 'gender') {
+          const k = roomKey(o.target.dormitoryName, o.target.roomName)
+          if (!roomGenderMap.has(k)) roomGenderMap.set(k, o.change.value)
+        } else if (o.target.kind === 'bed' && o.change.attr === 'active') {
+          if (!bedActiveMap.has(o.target.bedId)) bedActiveMap.set(o.target.bedId, o.change.value)
+        }
+      }
+      for (const dorm of tree) {
+        const dormSelfActive = dormActiveMap.has(dorm.dormitoryName) ? dormActiveMap.get(dorm.dormitoryName)! : dorm.active
+        let anyRoomActive = false
+        for (const room of dorm.rooms) {
+          const k = roomKey(dorm.dormitoryName, room.roomName)
+          let roomSelfActive: boolean
+          if (roomActiveMap.has(k)) roomSelfActive = roomActiveMap.get(k)!
+          else if (!dormSelfActive) roomSelfActive = false
+          else roomSelfActive = room.active
+          if (roomGenderMap.has(k)) room.roomGender = roomGenderMap.get(k)!
+          let anyBedActive = false
+          for (const bed of room.beds) {
+            const baseBed = bed.active !== false
+            let bedFinal: boolean
+            if (bedActiveMap.has(bed.bedId)) bedFinal = bedActiveMap.get(bed.bedId)!
+            else if (!roomSelfActive) bedFinal = false
+            else bedFinal = baseBed
+            bed.active = bedFinal
+            if (bedFinal) anyBedActive = true
+          }
+          if (anyBedActive) roomSelfActive = true
+          room.active = roomSelfActive
+          if (roomSelfActive) anyRoomActive = true
+        }
+        dorm.active = anyRoomActive ? true : dormSelfActive
+      }
+      return tree
+    }
+
+    // --- Editing-target syncing ---
+
+    /**
+     * When the editing target changes, load that configuration's snapshot
+     * into the working `dormitories` ref. Suppress the autosave watcher
+     * during the load so the swap doesn't immediately write back.
+     */
+    watch(selectedConfigurationId, (newId) => {
+      if (!newId) return
+      const c = configurations.value.find(x => x.id === newId)
+      if (!c) return
+      _suppressAutoSave = true
+      dormitories.value = _cloneDormitories(c.dormitories)
+      nextTick(() => { _suppressAutoSave = false })
+    })
+
+    /**
+     * Auto-save the working `dormitories` ref back to the selected
+     * configuration's snapshot. Debounced so a flurry of edits collapses
+     * into a single write.
+     */
+    let _cutsAutoSaveTimer: ReturnType<typeof setTimeout> | null = null
+    watch(
+      dormitories,
+      () => {
+        if (_suppressAutoSave) return
+        if (configurations.value.length === 0) return
+        if (!selectedConfigurationId.value) return
+        if (_cutsAutoSaveTimer) clearTimeout(_cutsAutoSaveTimer)
+        _cutsAutoSaveTimer = setTimeout(() => {
+          const c = configurations.value.find(x => x.id === selectedConfigurationId.value)
+          if (!c) return
+          c.dormitories = _cloneDormitories(dormitories.value)
+          c.updatedAt = new Date().toISOString()
+        }, 500)
+      },
+      { deep: true }
+    )
+
     // Auto-save watcher: debounced save of dormitories to active layout
     let _autoSaveTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -995,12 +1427,42 @@ export const useDormitoryStore = defineStore(
 
       // Layout deprecation / migration
       layoutMigrationComplete,
+
+      // Configuration cuts model
+      configurations,
+      configurationTemplates,
+      selectedConfigurationId,
+      cutsModelMigrationComplete,
+      currentConfiguration,
+      configurationCovering,
+      cutAt,
+      deleteCut,
+      updateConfigurationDormitories,
+      renameConfiguration,
+      saveConfigurationAsTemplate,
+      deleteConfigurationTemplate,
+      renameConfigurationTemplate,
+      selectConfiguration,
+      migrateToCutsModel,
     }
   },
   {
     persist: {
       key: 'dormAssignments-dormitories',
-      paths: ['dormitories', 'configName', 'layouts', 'activeLayoutId', 'bedShapeVersion', 'overrides', 'presets', 'layoutMigrationComplete'],
+      paths: [
+        'dormitories',
+        'configName',
+        'layouts',
+        'activeLayoutId',
+        'bedShapeVersion',
+        'overrides',
+        'presets',
+        'layoutMigrationComplete',
+        'configurations',
+        'configurationTemplates',
+        'selectedConfigurationId',
+        'cutsModelMigrationComplete',
+      ],
     },
   }
 )

--- a/src/stores/validationStore.overrideConflict.test.ts
+++ b/src/stores/validationStore.overrideConflict.test.ts
@@ -80,7 +80,7 @@ describe('validationStore — overrideConflict warning', () => {
       effectiveTo: '2026-07-14',
     })
     const warnings = useValidationStore().getWarningsForBed('B01')
-    expect(warnings.some(w => /inactive.*override/i.test(w))).toBe(true)
+    expect(warnings.some(w => /inactive during stay/i.test(w))).toBe(true)
   })
 
   it('does NOT flag when override window is outside the stay', () => {
@@ -92,7 +92,7 @@ describe('validationStore — overrideConflict warning', () => {
       effectiveTo: '2026-08-15',
     })
     const warnings = useValidationStore().getWarningsForBed('B01')
-    expect(warnings.some(w => /inactive.*override/i.test(w))).toBe(false)
+    expect(warnings.some(w => /inactive during stay/i.test(w))).toBe(false)
   })
 
   it('flags when a dormitory-level override cascades to close the bed during the stay', () => {
@@ -104,7 +104,7 @@ describe('validationStore — overrideConflict warning', () => {
       effectiveTo: '2026-07-13',
     })
     const warnings = useValidationStore().getWarningsForBed('B01')
-    expect(warnings.some(w => /inactive.*override/i.test(w))).toBe(true)
+    expect(warnings.some(w => /inactive during stay/i.test(w))).toBe(true)
   })
 
   it('does not unassign the guest — assignment persists despite the warning', () => {

--- a/src/stores/validationStore.ts
+++ b/src/stores/validationStore.ts
@@ -155,12 +155,13 @@ export const useValidationStore = defineStore('validation', () => {
       warnings.push('Needs Lower Bunk')
     }
 
-    // Override conflict: a time-based override has made this bed (or its
-    // room/dorm) inactive at some point during the guest's stay. Doesn't
-    // auto-unassign — surfaces a non-blocking warning so the operator can
-    // re-place the guest at their own pace.
+    // Time-based configuration check: the bed (or its room/dorm) is
+    // inactive at some point during the guest's stay according to the
+    // active configuration. Doesn't auto-unassign — surfaces a
+    // non-blocking warning so the operator can re-place at their own
+    // pace.
     if (!dormitoryStore.isBedActiveDuringStay(bed.bedId, guest.arrival, guest.departure)) {
-      warnings.push('Bed inactive during stay (override active)')
+      warnings.push('Bed inactive during stay')
     }
 
     // Check for family/group separation warnings - DISABLED

--- a/src/types/TimelineConfiguration.ts
+++ b/src/types/TimelineConfiguration.ts
@@ -1,0 +1,38 @@
+/**
+ * Timeline of full configurations (see `specs/ConfigurationCuts.md`).
+ *
+ * Replaces the "base + dated overrides + preset templates" model with
+ * a flat sequence of independent configuration snapshots, each
+ * covering its window between cut points.
+ */
+
+import type { Dormitory } from './Dormitory'
+
+export interface TimelineConfiguration {
+  id: string
+  /**
+   * Inclusive start date (ISO `YYYY-MM-DD`). `null` is the special
+   * "from the start of time" marker — there is exactly ONE
+   * configuration with `effectiveFrom: null` at all times (the
+   * initial configuration). Sort order is `effectiveFrom` ascending
+   * with the null one always first.
+   */
+  effectiveFrom: string | null
+  /** Operator-visible name. Defaults to "Configuration N". */
+  name: string
+  /**
+   * Full snapshot of the dormitory tree. Not a delta — every
+   * configuration is independent of its neighbours.
+   */
+  dormitories: Dormitory[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ConfigurationTemplate {
+  id: string
+  name: string
+  description?: string
+  dormitories: Dormitory[]
+  createdAt: string
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,7 +43,8 @@ export { DEFAULT_SETTINGS, GROUP_TYPE_LABELS, DEFAULT_GROUP_PLACEMENT_ORDER, DEF
 // Room Layout types
 export type { RoomLayout } from './RoomLayout'
 
-// Time-based override types
+// Time-based override types (deprecated — kept for one release as
+// the migration source for ConfigurationCuts).
 export type {
   ConfigOverride,
   OverridePreset,
@@ -51,6 +52,9 @@ export type {
   OverrideAttribute,
   PresetTemplateEntry,
 } from './Overrides'
+
+// Configuration cuts (current model — see specs/ConfigurationCuts.md)
+export type { TimelineConfiguration, ConfigurationTemplate } from './TimelineConfiguration'
 
 // Storage types
 export type { StorageData, LegacyStorageData } from './Storage'


### PR DESCRIPTION
## Summary
A substantial rework of the time-based configuration feature per [`specs/ConfigurationCuts.md`](./specs/ConfigurationCuts.md). The override / preset / one-off vocabulary proved confusing in practice; this PR reframes the model:

- Each segment of the timeline is a full **Configuration** (a snapshot of `dormitories[]`), not a delta on a base.
- The fundamental editing action is **Cut at date D** — split the configuration covering D into two segments. The new segment starts from D, runs to the next cut (or forever), and begins as a copy of the original. You then edit it independently.
- **Templates** replace presets: named snapshots saved off the timeline. Applying a template = cut at date + paste the template snapshot.

Renames operator-visible everywhere: override / preset / one-off → **Configuration / Template / Cut**.

## Migration (idempotent, runs on first load)
- 0 overrides + 0 presets → seed one initial Configuration (`effectiveFrom: null`, name "Default") from the current base.
- Otherwise → compute segment boundaries from existing overrides; for each segment, snapshot the effective tree via the legacy override-resolution path; freeze as a `TimelineConfiguration`. Each preset becomes a `ConfigurationTemplate` (snapshot of base after applying the preset's entries). Old `overrides[]` / `presets[]` are emptied (retained in schema for rollback).

Smoke-tested: legacy state with a preset application Jul 4-11 migrated cleanly to three configurations (Default / Cleaning Week / Default) plus one template (Cleaning Week).

## What's new in the UI
- `ConfigurationsSection` (replaces `PresetsAndOverridesSection`).
- `ConfigurationTimelineBar` (replaces `OverrideTimelineBar`). Click a segment → selects it as the editing target. The dormitory editor below operates on the selected configuration's snapshot via auto-save.
- `CutPopover` (replaces `OneOffOverrideModal`). Date + name + "Start from" picker: Empty copy of current / Copy from another configuration / Use a template.
- Editing bar between timeline and dormitory editor: Rename / Save as template / Delete cut.
- Templates card: list / rename / delete.

## Test plan
- [x] 12 new tests for the cuts model (migration paths, cutAt with all source modes, deleteCut refusing the initial, dormitoriesAt routing post-migration).
- [x] Updated existing validation/drop tests for the new warning text "Bed inactive during stay".
- [x] Full suite passes (154/154).
- [x] `npm run build` clean (vue-tsc + vite).
- [x] Dev smoke: seeded legacy override + preset state, watched the migration produce the right timeline; preset became a template; cut popover opens.
- [ ] Netlify preview manual check on a real dataset.

## Rollback path
Old types (`ConfigOverride`, `OverridePreset`, etc.) stay in the codebase for one release. `overrides[]` and `presets[]` fields persist (emptied). `cutsModelMigrationComplete` flag can be reset via localStorage to re-run migration.

Version tag bumped to `v260614-22:02`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)