### PR TITLE
Move 'Suggest Groups' to Table View, scoped to view-date unassigned

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@
           <span v-if="currentBranch && currentBranch !== 'main'" class="branch-indicator">
             ({{ currentBranch }} branch)
           </span>
-          <span class="version-tag">v260614-22:33</span>
+          <span class="version-tag">v260614-22:39</span>
         </h1>
         <button class="tour-btn" @click="startTour" title="Take a guided tour">
           ?
@@ -80,6 +80,14 @@
               <!-- Controls row: actions on the left, search on the right -->
               <div class="search-section">
                 <button class="btn-add-guest-sm" @click="handleAddGuestClick">+ Add</button>
+                <button
+                  class="btn-suggest-groups-sm"
+                  :disabled="unassignedAtViewDate.length === 0 || !guestStore.hasGuestsWithEmail"
+                  :title="`Suggest groups for ${unassignedAtViewDate.length} unassigned guest${unassignedAtViewDate.length === 1 ? '' : 's'} on this date`"
+                  @click="handleSuggestGroupsForView"
+                >
+                  Suggest Groups
+                </button>
                 <button class="btn-sort" @click="showSortModal = true" :title="sortDescription">
                   <span class="sort-icon">↕</span>
                   Sort
@@ -297,6 +305,7 @@ import { useGuestStore, useDormitoryStore, useAssignmentStore } from '@/stores'
 import { TabNavigation, ConfirmDialog, FloatingActionBar, SortConfigModal, OverlapConfirmDialog, GroupConflictDialog, ImportSummaryDialog } from '@/shared/components'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { useSortConfig } from '@/shared/composables/useSortConfig'
+import { parseLocalDate } from '@/shared/composables/useUtils'
 
 // Feature components
 import { HintBanner } from '@/features/hints/components'
@@ -472,6 +481,34 @@ const confirmDialog = ref({
 // Computed properties
 const unassignedCount = computed(() => assignmentStore.unassignedCount)
 const assignedCount = computed(() => assignmentStore.assignedCount)
+
+/**
+ * Unassigned guests whose stay covers the current View Date. Used by
+ * Table View's "Suggest Groups" so suggestions are scoped to the
+ * cohort the operator is actually looking at — same filter as
+ * `GuestList` with `:show-assigned="false"` + `:view-date="viewDate"`.
+ */
+const unassignedAtViewDate = computed(() => {
+  const vd = viewDate.value?.getTime()
+  return guestStore.guests.filter(g => {
+    if (assignmentStore.assignments.has(g.id)) return false
+    if (vd === undefined) return true
+    if (!g.arrival || !g.departure) return true
+    const arrival = parseLocalDate(g.arrival).getTime()
+    const departure = parseLocalDate(g.departure).getTime()
+    return vd >= arrival && vd < departure
+  })
+})
+
+function handleSuggestGroupsForView() {
+  const eligible = unassignedAtViewDate.value
+  const count = guestStore.suggestGroupsByEmail(eligible)
+  if (count > 0) {
+    showStatus(`Found ${count} group suggestion${count === 1 ? '' : 's'} among ${eligible.length} unassigned guest${eligible.length === 1 ? '' : 's'} on this date`, 'success')
+  } else {
+    showStatus('No new group suggestions among unassigned guests on this date', 'info')
+  }
+}
 
 // Guest list ref for add guest modal
 const guestListRef = ref<InstanceType<typeof GuestList> | null>(null)
@@ -1287,6 +1324,28 @@ function stopResize() {
 
   &:hover {
     background: #2563eb;
+  }
+}
+
+.btn-suggest-groups-sm {
+  padding: 6px 10px;
+  background: white;
+  color: #4f46e5;
+  border: 1px solid #4f46e5;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+
+  &:hover { background: #eef2ff; }
+
+  &:disabled {
+    color: #9ca3af;
+    border-color: #d1d5db;
+    background: #f9fafb;
+    cursor: not-allowed;
   }
 }
 

--- a/src/features/guest-data/components/GuestDataView.vue
+++ b/src/features/guest-data/components/GuestDataView.vue
@@ -14,13 +14,6 @@
           @upload-error="handleUploadError"
           @load-test-data="handleLoadTestData"
         />
-        <button
-          class="btn btn-suggest-groups"
-          :disabled="!guestStore.hasGuestsWithEmail"
-          @click="handleSuggestGroups"
-        >
-          Suggest Groups
-        </button>
       </div>
     </div>
 
@@ -237,15 +230,6 @@ async function handleLoadTestData() {
   }
 }
 
-
-function handleSuggestGroups() {
-  const count = guestStore.suggestGroupsByEmail()
-  if (count > 0) {
-    showStatus(`Found ${count} group suggestion${count === 1 ? '' : 's'} by shared email`, 'success')
-  } else {
-    showStatus('No new group suggestions found — guests may already be grouped', 'info')
-  }
-}
 
 function handleDeleteAll() {
   confirmAction(

--- a/src/stores/guestStore.ts
+++ b/src/stores/guestStore.ts
@@ -187,12 +187,22 @@ export const useGuestStore = defineStore(
     const hasGroupSuggestions = computed(() => suggestedGroups.value.size > 0)
     const groupSuggestionCount = computed(() => suggestedGroups.value.size)
 
-    // Group suggestion actions
-    function suggestGroupsByEmail(): number {
+    /**
+     * Group-by-email suggestion engine.
+     *
+     * Default: scan every guest in the store. Pass `eligibleGuests` to
+     * scope the scan — used by Table View's "Suggest Groups" so it only
+     * considers unassigned-as-of-the-view-date guests.
+     *
+     * Returns the number of group suggestions produced (0 if nothing
+     * new was found).
+     */
+    function suggestGroupsByEmail(eligibleGuests?: Guest[]): number {
       const emailMap = new Map<string, Guest[]>()
+      const pool = eligibleGuests ?? guests.value
 
       // Build email → guests map
-      guests.value.forEach(guest => {
+      pool.forEach(guest => {
         if (guest.email && guest.email.trim()) {
           const normalizedEmail = guest.email.trim().toLowerCase()
           let bucket = emailMap.get(normalizedEmail)


### PR DESCRIPTION
## Summary
Per feedback, the Suggest Groups action moves from All Reservations to Table View where it's actually useful, and is scoped to the **cohort the operator is looking at**: unassigned guests whose stay covers the current View Date.

- New button in Table View's Unassigned Guests panel header.
- Removed from GuestDataView (All Reservations).
- Disabled tooltip surfaces the count of eligible guests so the operator knows what's about to be scanned.
- \`guestStore.suggestGroupsByEmail(eligibleGuests?)\` gains an optional pool param — default behavior unchanged for any other callers.

## Test plan
- [x] Full suite passes (155/155).
- [x] \`npm run build\` clean.
- [ ] Manual UI smoke: click Suggest Groups with different View Dates and confirm only unassigned guests on that date get scanned.

Version tag bumped to \`v260614-22:39\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)