### PR TITLE
Fix duplicate-guest bug: bedId collision when rooms share name prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,7 @@ Each store persists independently under its own key. The `assignmentStore` manag
 ### Bed ID Generation
 - Format: `[RoomPrefix][BedNumber]` (e.g., "MA01", "FR03")
 - Auto-generated based on room name abbreviations
-- Must be unique across all dormitories
+- **INVARIANT: `bed.bedId` must be globally unique within a layout tree.** `assignmentStore.guestToBed`, `bedLookupMap`, validation, and print views all key on `bedId`; a collision silently collapses two beds into one slot and makes one guest appear in multiple rooms. **Always generate via `useBedIdGenerator.generateUniqueBedId(roomName, existingIds)`** (seed `existingIds` with every bedId across the active config plus any pending in-flight beds). Never inline a prefix+position scheme — `dormitoryStore.healDuplicateBedIds` exists to repair legacy collisions and `bedLookupMap` logs a `console.warn` on detection, but the only correct preventive path is the helper.
 
 ## Important Implementation Notes
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@
           <span v-if="currentBranch && currentBranch !== 'main'" class="branch-indicator">
             ({{ currentBranch }} branch)
           </span>
-<span class="version-tag">v260614-23:35</span>
+<span class="version-tag">v260618-08:52</span>
         </h1>
         <button class="tour-btn" @click="startTour" title="Take a guided tour">
           ?

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@
           <span v-if="currentBranch && currentBranch !== 'main'" class="branch-indicator">
             ({{ currentBranch }} branch)
           </span>
-<span class="version-tag">v260618-08:52</span>
+<span class="version-tag">v260618-09:04</span>
         </h1>
         <button class="tour-btn" @click="startTour" title="Take a guided tour">
           ?
@@ -35,6 +35,34 @@
         />
         <!-- <AssignmentStats class="header-stats" data-tour="header-stats" /> -->
       </div>
+    </div>
+
+    <!-- Bed ID heal notice: shown once after the auto-heal renames any
+         duplicate bedIds from legacy data. Dismiss persists. -->
+    <div
+      v-if="dormitoryStore.bedIdHealRenames.length > 0"
+      class="bedid-heal-banner"
+      role="alert"
+    >
+      <div class="bedid-heal-banner__body">
+        <strong>Duplicate bed IDs were detected and renamed.</strong>
+        Two or more beds shared the same internal ID, which made one guest
+        appear in multiple rooms. The following beds were given fresh
+        unique IDs. Any assignments stay pinned to the original ID, so
+        you may need to re-verify which bed each guest belongs in:
+        <ul class="bedid-heal-banner__list">
+          <li v-for="r in dormitoryStore.bedIdHealRenames" :key="`${r.dormitoryName}-${r.oldId}-${r.newId}`">
+            {{ r.dormitoryName }} / {{ r.roomName }}: <code>{{ r.oldId }}</code> → <code>{{ r.newId }}</code>
+          </li>
+        </ul>
+      </div>
+      <button
+        class="bedid-heal-banner__dismiss"
+        @click="dormitoryStore.dismissBedIdHealNotice"
+        title="Dismiss"
+      >
+        ✕
+      </button>
     </div>
 
     <!-- Tab Navigation -->
@@ -951,6 +979,52 @@ function stopResize() {
       font-weight: 400;
       margin-left: 6px;
       letter-spacing: 0.02em;
+    }
+  }
+}
+
+.bedid-heal-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin: 8px 16px;
+  padding: 12px 14px;
+  background-color: #fff7ed;
+  border: 1px solid #fdba74;
+  border-left: 4px solid #ea580c;
+  border-radius: 6px;
+  color: #7c2d12;
+  font-size: 0.85rem;
+  line-height: 1.4;
+
+  &__body {
+    flex: 1;
+  }
+
+  &__list {
+    margin: 6px 0 0;
+    padding-left: 18px;
+
+    code {
+      background: rgba(124, 45, 18, 0.08);
+      padding: 1px 5px;
+      border-radius: 3px;
+      font-size: 0.8rem;
+    }
+  }
+
+  &__dismiss {
+    background: transparent;
+    border: none;
+    color: #7c2d12;
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 4px 6px;
+    border-radius: 4px;
+
+    &:hover {
+      background: rgba(124, 45, 18, 0.1);
     }
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@
           <span v-if="currentBranch && currentBranch !== 'main'" class="branch-indicator">
             ({{ currentBranch }} branch)
           </span>
-<span class="version-tag">v260618-09:04</span>
+<span class="version-tag">v260618-09:08</span>
         </h1>
         <button class="tour-btn" @click="startTour" title="Take a guided tour">
           ?

--- a/src/features/csv/components/RoomConfigCSV.vue
+++ b/src/features/csv/components/RoomConfigCSV.vue
@@ -52,6 +52,7 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useCSV } from '../composables/useCSV'
 import { useDormitoryStore } from '@/stores/dormitoryStore'
+import { useBedIdGenerator } from '@/shared/composables/useBedIdGenerator'
 import { ConfirmDialog } from '@/shared/components'
 import type { Dormitory, RoomLayout } from '@/types'
 import { parseRoomGender, parseBedType } from '@/types/Constants'
@@ -81,6 +82,7 @@ const importModeMessage = ref('')
 
 const dormitoryStore = useDormitoryStore()
 const { generateCSV, downloadCSV, generateTimestampedFilename, parseCSVRow } = useCSV()
+const { generateUniqueBedId } = useBedIdGenerator()
 
 // Close export menu when clicking outside
 function handleClickOutside(event: MouseEvent) {
@@ -322,15 +324,28 @@ function parseRoomConfigCSV(csvText: string): Dormitory[] {
 
   const headers = lines[startLine].split(',').map(h => h.trim().replace(/"/g, ''))
   const dormitoriesMap = new Map<string, Dormitory>()
+  const seenBedIds = new Set<string>()
+  const renamedBedIds: Array<{ oldId: string; newId: string; roomName: string }> = []
 
   for (let i = startLine + 1; i < lines.length; i++) {
     const values = parseCSVRow(lines[i])
 
     const dormitoryName = values[headers.indexOf('Dormitory Name')]?.trim()
     const roomName = values[headers.indexOf('Room Name')]?.trim()
-    const bedId = values[headers.indexOf('Bed ID')]?.trim()
+    const rawBedId = values[headers.indexOf('Bed ID')]?.trim()
 
-    if (!dormitoryName || !roomName || !bedId) continue
+    if (!dormitoryName || !roomName || !rawBedId) continue
+
+    // Dedupe bedId in case the CSV has collisions (legacy export from
+    // before the addBed uniqueness fix, or a hand-edited file). Same
+    // helper used everywhere else so the renaming rule is consistent.
+    let bedId = rawBedId
+    if (seenBedIds.has(bedId)) {
+      const newId = generateUniqueBedId(roomName, Array.from(seenBedIds))
+      renamedBedIds.push({ oldId: bedId, newId, roomName })
+      bedId = newId
+    }
+    seenBedIds.add(bedId)
 
     // Get or create dormitory
     if (!dormitoriesMap.has(dormitoryName)) {
@@ -364,6 +379,13 @@ function parseRoomConfigCSV(csvText: string): Dormitory[] {
       assignments: [],
       active: values[headers.indexOf('Bed Active')]?.toLowerCase() !== 'no',
     })
+  }
+
+  if (renamedBedIds.length > 0) {
+    console.warn(
+      `[RoomConfigCSV] Renamed ${renamedBedIds.length} duplicate bed ID${renamedBedIds.length === 1 ? '' : 's'} during import:`,
+      renamedBedIds,
+    )
   }
 
   return Array.from(dormitoriesMap.values())

--- a/src/features/dormitories/components/RoomConfigCard.vue
+++ b/src/features/dormitories/components/RoomConfigCard.vue
@@ -70,6 +70,7 @@ import { useGuestStore } from '@/stores/guestStore'
 import { useDormitoryStore } from '@/stores/dormitoryStore'
 import { staysOverlap, parseLocalDate } from '@/shared/composables/useUtils'
 import { useHints } from '@/features/hints/composables/useHints'
+import { useBedIdGenerator } from '@/shared/composables/useBedIdGenerator'
 import type { Room, Bed } from '@/types'
 
 interface Props {
@@ -87,6 +88,7 @@ const assignmentStore = useAssignmentStore()
 const guestStore = useGuestStore()
 const dormitoryStore = useDormitoryStore()
 const { highlightedElement } = useHints()
+const { generateUniqueBedId } = useBedIdGenerator()
 
 const localRoom = ref<Room>({ ...props.room, beds: [...props.room.beds] })
 
@@ -332,9 +334,20 @@ function handleRemoveRoom() {
 
 function addBed() {
   const newPosition = localRoom.value.beds.length + 1
-  const roomPrefix = localRoom.value.roomName.substring(0, 2).toUpperCase()
+  const existingIds = new Set<string>()
+  for (const dorm of dormitoryStore.dormitories) {
+    for (const room of dorm.rooms) {
+      for (const bed of room.beds) {
+        existingIds.add(bed.bedId)
+      }
+    }
+  }
+  for (const bed of localRoom.value.beds) {
+    existingIds.add(bed.bedId)
+  }
+  const newBedId = generateUniqueBedId(localRoom.value.roomName, Array.from(existingIds))
   const newBed: Bed = {
-    bedId: `${roomPrefix}${String(newPosition).padStart(2, '0')}`,
+    bedId: newBedId,
     bedType: 'single',
     position: newPosition,
     assignments: [],

--- a/src/stores/dormitoryStore.bedIdCollision.test.ts
+++ b/src/stores/dormitoryStore.bedIdCollision.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for bedId uniqueness + the heal pass that fixes legacy
+ * duplicate-bedId data caused by the pre-fix `addBed()` collision bug.
+ *
+ * Two rooms whose names share their first two characters (e.g.
+ * "Mountain House" and "Mosquito Hall" → both `MO`) used to produce
+ * colliding bed IDs. Since `assignmentStore.guestToBed` keys by
+ * `bedId`, a colliding bed made one guest appear in two rooms.
+ *
+ * These tests cover:
+ *  1. `useBedIdGenerator.generateUniqueBedId` resolves the collision
+ *     scenario when seeded with already-taken IDs.
+ *  2. `dormitoryStore.healDuplicateBedIds` renames duplicate bedIds
+ *     and reports the renames.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useDormitoryStore } from './dormitoryStore'
+import { useBedIdGenerator } from '@/shared/composables/useBedIdGenerator'
+import type { Dormitory } from '@/types'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { store = {} },
+    key: () => null,
+    length: 0,
+  }
+})()
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+if (typeof globalThis.crypto === 'undefined') {
+  ;(globalThis as { crypto: Crypto }).crypto = {
+    randomUUID: () => Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`,
+  } as Crypto
+} else if (typeof globalThis.crypto.randomUUID !== 'function') {
+  globalThis.crypto.randomUUID = () =>
+    Math.random().toString(36).slice(2) as `${string}-${string}-${string}-${string}-${string}`
+}
+
+describe('useBedIdGenerator.generateUniqueBedId', () => {
+  const { generateBedId, generateUniqueBedId } = useBedIdGenerator()
+
+  it('produces matching prefix for prefix-colliding room names', () => {
+    // Documents the underlying behavior that made the original bug
+    // possible: two distinct room names map to the same prefix.
+    expect(generateBedId('Mountain House', 0)).toBe('MH01')
+    expect(generateBedId('Mosquito Hall', 0)).toBe('MH01')
+  })
+
+  it('iterates the suffix to avoid a collision with existing IDs', () => {
+    // The seed represents beds already created in "Mountain House".
+    // Adding a bed in "Mosquito Hall" (same MH prefix) must NOT reuse
+    // MH01–MH03.
+    const seed = ['MH01', 'MH02', 'MH03']
+    const next = generateUniqueBedId('Mosquito Hall', seed)
+    expect(next).toBe('MH04')
+  })
+
+  it('still hands out the natural ID when nothing collides', () => {
+    expect(generateUniqueBedId('Big Dorm', [])).toBe('BD01')
+    expect(generateUniqueBedId('Big Dorm', ['MA01', 'FR03'])).toBe('BD01')
+  })
+})
+
+describe('dormitoryStore.healDuplicateBedIds', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorageMock.clear()
+  })
+
+  function makeCollidingTree(): Dormitory[] {
+    return [
+      {
+        dormitoryName: 'Main Building',
+        active: true,
+        rooms: [
+          {
+            roomName: 'Mountain House',
+            roomGender: 'M',
+            active: true,
+            beds: [
+              { bedId: 'MH01', bedType: 'single', position: 1, assignments: [] },
+              { bedId: 'MH02', bedType: 'single', position: 2, assignments: [] },
+            ],
+          },
+          {
+            // Different room, same prefix → same generated IDs under
+            // the pre-fix `addBed()` code path.
+            roomName: 'Mosquito Hall',
+            roomGender: 'F',
+            active: true,
+            beds: [
+              { bedId: 'MH01', bedType: 'single', position: 1, assignments: [] },
+              { bedId: 'MH02', bedType: 'single', position: 2, assignments: [] },
+            ],
+          },
+        ],
+      },
+    ]
+  }
+
+  it('eager watcher heals duplicate bedIds at hydration time and records them on bedIdHealRenames', () => {
+    const store = useDormitoryStore()
+    // Importing into the empty store triggers the eager heal watcher,
+    // which mirrors what happens at pinia-persistedstate hydration.
+    store.importDormitories(makeCollidingTree())
+
+    // All bedIds across the tree must be globally unique post-heal.
+    const allBedIds = store.dormitories
+      .flatMap(d => d.rooms)
+      .flatMap(r => r.beds)
+      .map(b => b.bedId)
+    expect(new Set(allBedIds).size).toBe(allBedIds.length)
+
+    // First occurrence keeps its ID; later duplicates are renamed.
+    const mountainHouse = store.dormitories[0].rooms.find(r => r.roomName === 'Mountain House')!
+    expect(mountainHouse.beds.map(b => b.bedId)).toEqual(['MH01', 'MH02'])
+
+    // Renames are surfaced on the store for the dismissable banner.
+    expect(store.bedIdHealRenames.length).toBeGreaterThanOrEqual(2)
+    for (const r of store.bedIdHealRenames) {
+      expect(r.roomName).toBe('Mosquito Hall')
+      expect(r.dormitoryName).toBe('Main Building')
+      expect(['MH01', 'MH02']).toContain(r.oldId)
+      expect(r.newId).not.toBe(r.oldId)
+    }
+  })
+
+  it('dismissBedIdHealNotice clears the rename list', () => {
+    const store = useDormitoryStore()
+    store.importDormitories(makeCollidingTree())
+    expect(store.bedIdHealRenames.length).toBeGreaterThan(0)
+    store.dismissBedIdHealNotice()
+    expect(store.bedIdHealRenames).toEqual([])
+  })
+
+  it('explicit healDuplicateBedIds call dedupes new collisions introduced after hydration', () => {
+    const store = useDormitoryStore()
+    // First import is unique → eager watcher records nothing.
+    store.importDormitories([
+      {
+        dormitoryName: 'Main Building',
+        active: true,
+        rooms: [
+          {
+            roomName: 'Alpha Room',
+            roomGender: 'M',
+            active: true,
+            beds: [
+              { bedId: 'AR01', bedType: 'single', position: 1, assignments: [] },
+            ],
+          },
+        ],
+      },
+    ])
+    expect(store.bedIdHealRenames).toEqual([])
+
+    // Simulate a buggy add-bed path producing a duplicate.
+    store.dormitories[0].rooms[0].beds.push({
+      bedId: 'AR01',
+      bedType: 'single',
+      position: 2,
+      assignments: [],
+    })
+
+    const renames = store.healDuplicateBedIds()
+    expect(renames.length).toBe(1)
+    expect(renames[0].oldId).toBe('AR01')
+    expect(renames[0].newId).not.toBe('AR01')
+
+    const ids = store.dormitories[0].rooms[0].beds.map(b => b.bedId)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('is a no-op on a tree that already has unique bedIds', () => {
+    const store = useDormitoryStore()
+    store.importDormitories([
+      {
+        dormitoryName: 'Main Building',
+        active: true,
+        rooms: [
+          {
+            roomName: 'Alpha Room',
+            roomGender: 'M',
+            active: true,
+            beds: [
+              { bedId: 'AR01', bedType: 'single', position: 1, assignments: [] },
+              { bedId: 'AR02', bedType: 'single', position: 2, assignments: [] },
+            ],
+          },
+        ],
+      },
+    ])
+
+    const renames = store.healDuplicateBedIds()
+    expect(renames).toEqual([])
+  })
+})

--- a/src/stores/dormitoryStore.ts
+++ b/src/stores/dormitoryStore.ts
@@ -127,20 +127,45 @@ export const useDormitoryStore = defineStore(
       return allBeds
     })
 
-    // Pre-built lookup maps for O(1) bed lookups (rebuilt when dormitories change)
+    // Pre-built lookup maps for O(1) bed lookups (rebuilt when dormitories change).
+    //
+    // INVARIANT: bed.bedId must be globally unique within `dormitories.value`.
+    // Two beds with the same ID silently collapse into one Map entry, which
+    // is exactly the bug that produced the "guest appears in two rooms"
+    // symptom historically — see healDuplicateBedIds + the dedicated test.
+    // Bed creation must go through useBedIdGenerator.generateUniqueBedId.
+    // We log a console.warn here so any future regression surfaces in the
+    // browser console the first time the lookup map is rebuilt, instead of
+    // showing up as a UX weirdness in another tab much later.
     const bedLookupMap = computed(() => {
       const bedMap = new Map<string, Bed>()
       const roomMap = new Map<string, FlatRoom>()
       const dormMap = new Map<string, Dormitory>()
+      const duplicates: Array<{ bedId: string; rooms: string[] }> = []
+      const seenRooms = new Map<string, string[]>()
       for (const dormitory of dormitories.value) {
         for (const room of dormitory.rooms) {
           const flatRoom: FlatRoom = { ...room, dormitoryName: dormitory.dormitoryName }
           for (const bed of room.beds) {
+            if (bedMap.has(bed.bedId)) {
+              const prior = seenRooms.get(bed.bedId) ?? []
+              prior.push(`${dormitory.dormitoryName} / ${room.roomName}`)
+              seenRooms.set(bed.bedId, prior)
+              duplicates.push({ bedId: bed.bedId, rooms: prior })
+            } else {
+              seenRooms.set(bed.bedId, [`${dormitory.dormitoryName} / ${room.roomName}`])
+            }
             bedMap.set(bed.bedId, bed)
             roomMap.set(bed.bedId, flatRoom)
             dormMap.set(bed.bedId, dormitory)
           }
         }
+      }
+      if (duplicates.length > 0) {
+        console.warn(
+          `[dormitoryStore] Duplicate bedId(s) detected in lookup map — assignments will collide. Bed creation must use useBedIdGenerator.generateUniqueBedId; the auto-heal pass should also have caught this. Duplicates:`,
+          duplicates,
+        )
       }
       return { bedMap, roomMap, dormMap }
     })

--- a/src/stores/dormitoryStore.ts
+++ b/src/stores/dormitoryStore.ts
@@ -24,7 +24,15 @@ import type {
 } from '@/types'
 import { DEFAULT_COLORS } from '@/types'
 import { parseLocalDate } from '@/shared/composables/useUtils'
+import { useBedIdGenerator } from '@/shared/composables/useBedIdGenerator'
 import { useAssignmentStore } from './assignmentStore'
+
+export interface BedIdRename {
+  oldId: string
+  newId: string
+  roomName: string
+  dormitoryName: string
+}
 
 /**
  * Bed-shape schema version. Bump when changing bed structure so migration
@@ -428,6 +436,121 @@ export const useDormitoryStore = defineStore(
 
     function importDormitories(importedDormitories: Dormitory[]) {
       dormitories.value = importedDormitories
+    }
+
+    /**
+     * Renames performed by the most recent `healDuplicateBedIds()` run.
+     * Surfaced in a one-time banner so the operator can verify which
+     * beds were touched. Cleared once the banner is dismissed.
+     */
+    const bedIdHealRenames = ref<BedIdRename[]>([])
+
+    /**
+     * Dedupe `bedId` strings within each independent layout tree.
+     *
+     * The pre-fix `addBed()` used a 2-char room-name prefix plus the
+     * local bed position with no uniqueness check, so two rooms whose
+     * names shared their first two characters (e.g. "Mountain House" /
+     * "Mosquito Hall" → both `MO`) produced colliding bed IDs. Because
+     * `assignmentStore.guestToBed` keys by `bedId`, a colliding bed made
+     * one guest appear in two rooms simultaneously.
+     *
+     * This routine walks every layout tree (the live `dormitories` ref,
+     * each configuration's snapshot, each layout's snapshot, each
+     * template's snapshot) and renames any duplicate found WITHIN a
+     * given tree to a fresh unique ID via `generateUniqueBedId`. Each
+     * tree is deduped independently — bed IDs are expected to be shared
+     * across configurations / templates by design (same physical bed,
+     * preserved through cuts) so we do not dedupe across trees.
+     *
+     * Returns the list of renames performed. Existing assignments stay
+     * pinned to the OLD bedId, so they remain with whichever bed kept
+     * the original ID; the renamed bed loses its prior (incorrectly
+     * shared) assignment.
+     */
+    function healDuplicateBedIds(): BedIdRename[] {
+      const { generateUniqueBedId } = useBedIdGenerator()
+      const renames: BedIdRename[] = []
+
+      const dedupeTree = (tree: Dormitory[] | undefined) => {
+        if (!Array.isArray(tree)) return
+        const seen = new Set<string>()
+        for (const dorm of tree) {
+          if (!Array.isArray(dorm.rooms)) continue
+          for (const room of dorm.rooms) {
+            if (!Array.isArray(room.beds)) continue
+            for (const bed of room.beds) {
+              if (!bed.bedId) continue
+              if (seen.has(bed.bedId)) {
+                const oldId = bed.bedId
+                const newId = generateUniqueBedId(room.roomName || '', Array.from(seen))
+                bed.bedId = newId
+                seen.add(newId)
+                renames.push({
+                  oldId,
+                  newId,
+                  roomName: room.roomName,
+                  dormitoryName: dorm.dormitoryName,
+                })
+              } else {
+                seen.add(bed.bedId)
+              }
+            }
+          }
+        }
+      }
+
+      _suppressAutoSave = true
+      dedupeTree(dormitories.value)
+      for (const layout of layouts.value) {
+        dedupeTree(layout.dormitories)
+      }
+      for (const config of configurations.value) {
+        dedupeTree(config.dormitories)
+      }
+      for (const template of configurationTemplates.value) {
+        dedupeTree(template.dormitories)
+      }
+      nextTick(() => {
+        _suppressAutoSave = false
+      })
+
+      return renames
+    }
+
+    /**
+     * One-shot heal pass mirroring the `migrateBedAssignments` watcher:
+     * runs as soon as data is non-empty (after hydration or default
+     * init), records any renames on `bedIdHealRenames` for the banner,
+     * and disposes itself.
+     */
+    let _healDone = false
+    const _stopHealWatch = watch(
+      [dormitories, layouts, configurations, configurationTemplates],
+      () => {
+        if (_healDone) return
+        const hasData =
+          dormitories.value.length > 0 ||
+          layouts.value.length > 0 ||
+          configurations.value.length > 0 ||
+          configurationTemplates.value.length > 0
+        if (!hasData) return
+        // Guard BEFORE the heal call: with flush:'sync' + deep:true,
+        // renaming bedIds inside heal would otherwise re-trigger this
+        // very watcher synchronously and partially overwrite the
+        // rename list with a smaller second-pass result.
+        _healDone = true
+        const renames = healDuplicateBedIds()
+        if (renames.length > 0) {
+          bedIdHealRenames.value = renames
+        }
+        _stopHealWatch()
+      },
+      { immediate: true, deep: true, flush: 'sync' }
+    )
+
+    function dismissBedIdHealNotice() {
+      bedIdHealRenames.value = []
     }
 
     // --- Layout Management ---
@@ -1506,6 +1629,9 @@ export const useDormitoryStore = defineStore(
       initializeDefaultDormitories,
       importDormitories,
       migrateBedAssignments,
+      healDuplicateBedIds,
+      bedIdHealRenames,
+      dismissBedIdHealNotice,
 
       // Layout actions
       ensureLayoutsInitialized,
@@ -1569,6 +1695,7 @@ export const useDormitoryStore = defineStore(
         'configurationTemplates',
         'selectedConfigurationId',
         'cutsModelMigrationComplete',
+        'bedIdHealRenames',
       ],
     },
   }


### PR DESCRIPTION
## Summary

Operator reported a "duplicate guest" bug — one person appearing in two rooms — that turned out to be caused by colliding bed IDs. `addBed()` in `RoomConfigCard.vue` was generating `bedId` from `roomName.substring(0, 2).toUpperCase() + position` with no uniqueness check. Two rooms whose names share the first two characters (e.g. "Mountain House" / "Mosquito Hall" → both `MO`) produced identical bed IDs (`MO01`, `MO02`…). Since `assignmentStore.guestToBed` keys by `bedId`, assigning a guest to one bed made them appear in both rooms. The operator had been working around it by forcing room names to be very different.

A `useBedIdGenerator.generateUniqueBedId()` helper already existed but had zero callers — it was extracted Dec 1, 2025 in a refactor and the buggy feature was written Dec 3, 2025 without grepping for it.

## What changed

**Root fix** (`5e112e3`)
- `addBed()` now uses `generateUniqueBedId`, seeded with every bed ID across the active config plus the local room's pending beds.

**Heal legacy data** (`ea71e38`)
- `dormitoryStore.healDuplicateBedIds()` walks every layout tree (live dormitories, each configuration snapshot, each saved layout, each template) and renames duplicates per-tree via the helper. Eager one-shot watcher runs at hydration time.
- App.vue shows a dismissable orange banner naming every renamed bed so operators can verify which beds were touched. Persisted across reload until dismissed.
- `RoomConfigCSV` import now dedupes Bed IDs so a legacy export or hand-edited CSV with collisions can't reintroduce the bug. Logs a console warning.
- New test file with 7 cases covering the helper, eager heal, dismiss, explicit re-invocation, and no-op on clean trees. Writing the tests caught a real re-entry bug in the eager watcher (`flush:'sync' + deep:true` re-triggered during renames and clobbered the rename list).

**Future-proofing** (`4b9c494`)
- `dormitoryStore.bedLookupMap` now `console.warn`s when it observes a duplicate bedId — pure observability, fires zero times in normal use. Catches any future regression in the browser console immediately instead of as a UX symptom days later.
- CLAUDE.md "Bed ID Generation" section documents the invariant explicitly: bedId must be globally unique within a layout tree; always generate via the helper; never inline.

Deliberately NOT included: centralizing bed creation as a single store action, and branding `BedId` as an opaque type. Both would touch live-system behavior with no current bug to justify the risk — schedule for a quieter window.

## Migration impact for existing users

- **Most users**: nothing changes. Deploy and continue.
- **Users who hit the bug and worked around it** (like our reporter — used very different names): already safe. Renames don't regenerate IDs, so on-disk data stays valid.
- **Users still living with collisions**: the eager heal pass runs at hydration, renames the newer duplicates, and surfaces the banner. Existing assignments stay pinned to the surviving original ID; operator may need to re-verify which bed each guest belongs in. Recommend downloading a backup via Settings → Data Backup before applying.

## Test plan

- [x] `npm run test` — 165/165 passing, including 7 new bedId-collision tests
- [x] `npm run build` — type-check + production build clean
- [ ] Smoke: create two rooms with prefix-matching names ("Mountain House" / "Mosquito Hall"), add beds in each, confirm bed IDs differ
- [ ] Smoke: load a session that previously exhibited the duplication; confirm the heal banner appears, lists the renames, and the duplicate-guest symptom is gone
- [ ] Smoke: re-import a CSV with intentionally colliding Bed IDs; confirm console warning + auto-rename
- [ ] Smoke: dismiss the heal banner; confirm it stays dismissed across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)